### PR TITLE
E2e/update to latest repo

### DIFF
--- a/Examples/CocoaPodsExample/iOS_Extension_Example/MessagesViewController.h
+++ b/Examples/CocoaPodsExample/iOS_Extension_Example/MessagesViewController.h
@@ -8,6 +8,7 @@
 
 #import <Messages/Messages.h>
 
+API_AVAILABLE(ios(10.0))
 @interface MessagesViewController : MSMessagesAppViewController
 
 @end

--- a/Examples/CocoaPodsExample/iOS_Extension_Example/MessagesViewController.m
+++ b/Examples/CocoaPodsExample/iOS_Extension_Example/MessagesViewController.m
@@ -44,14 +44,14 @@
 
 #pragma mark - Conversation Handling
 
--(void)didBecomeActiveWithConversation:(MSConversation *)conversation {
+-(void)didBecomeActiveWithConversation:(MSConversation *)conversation NS_AVAILABLE_IOS(10_0){
     // Called when the extension is about to move from the inactive to active state.
     // This will happen when the extension is about to present UI.
     
     // Use this method to configure the extension and restore previously stored state.
 }
 
--(void)willResignActiveWithConversation:(MSConversation *)conversation {
+-(void)willResignActiveWithConversation:(MSConversation *)conversation NS_AVAILABLE_IOS(10_0){
     // Called when the extension is about to move from the active to inactive state.
     // This will happen when the user dissmises the extension, changes to a different
     // conversation or quits Messages.

--- a/Framework/Info.plist
+++ b/Framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.3.9</string>
+	<string>7.4.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Scripts/AppledocSettings.plist
+++ b/Scripts/AppledocSettings.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>--project-name</key>
+	<string>mParticle Apple SDK</string>
+	<key>--logformat</key>
+	<string>1</string>
+	<key>--verbose</key>
+	<string>4</string>
+	<key>--input</key>
+	<array>
+		<string>../mParticle-Apple-SDK/mParticle.h</string>
+		<string>../mParticle-Apple-SDK/Event</string>
+		<string>../mParticle-Apple-SDK/Ecommerce</string>
+		<string>../mParticle-Apple-SDK/Identity</string>
+		<string>../mParticle-Apple-SDK/Consent</string>
+		<string>../mParticle-Apple-SDK/MPEnums.h</string>
+		<string>../mParticle-Apple-SDK/Segments</string>
+	</array>
+	<key>--output</key>
+	<string>Docs</string>
+	<key>--no-create-docset</key>
+	<true/>
+	<key>--create-html</key>
+	<true/>
+	<key>--company-id</key>
+	<string>com.mparticle</string>
+	<key>--project-company</key>
+	<string>mParticle</string>
+</dict>
+</plist>

--- a/UnitTests/MPPersistenceControllerTests.mm
+++ b/UnitTests/MPPersistenceControllerTests.mm
@@ -19,32 +19,22 @@
 
 #define DATABASE_TESTS_EXPECTATIONS_TIMEOUT 1
 
-@interface MParticle ()
-+ (dispatch_queue_t)messageQueue;
-@end
-
-@interface MPPersistenceControllerTests : XCTestCase {
-    dispatch_queue_t messageQueue;
-}
+@interface MPPersistenceControllerTests : XCTestCase
 
 @end
-
 
 @implementation MPPersistenceControllerTests
 
 - (void)setUp {
     [super setUp];
     [MParticle sharedInstance];
-    messageQueue = [MParticle messageQueue];
     [[MPPersistenceController sharedInstance] openDatabase];
 }
 
 - (void)tearDown {
-    dispatch_sync(messageQueue, ^{
-        MPPersistenceController *persistence = [MPPersistenceController sharedInstance];
-        [persistence deleteRecordsOlderThan:[[NSDate date] timeIntervalSince1970]];
-        [persistence closeDatabase];
-    });
+    MPPersistenceController *persistence = [MPPersistenceController sharedInstance];
+    [persistence deleteRecordsOlderThan:[[NSDate date] timeIntervalSince1970]];
+    [persistence closeDatabase];
     
     [super tearDown];
 }
@@ -77,7 +67,7 @@
             sessions = [persistence fetchSessions];
         }
     };
-    dispatch_async(messageQueue, ^{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         workBlock();
     });
     workBlock();
@@ -88,155 +78,101 @@
     XCTAssertEqual(safe, 2);
     const char *version = sqlite3_libversion();
     NSString *stringVersion = [NSString stringWithCString:version encoding:NSUTF8StringEncoding];
-    XCTAssertEqualObjects(stringVersion, @"3.19.3");
+    XCTAssert([stringVersion isEqual:@"3.19.3"] || [stringVersion isEqual:@"3.22.0"]);
 }
 
 - (void)testSession {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Session test"];
     
-    dispatch_async(messageQueue, ^{
-        MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
-        session.attributesDictionary = [@{@"key1":@"value1"} mutableCopy];
-        
-        MPPersistenceController *persistence = [MPPersistenceController sharedInstance];
-        [persistence saveSession:session];
-        
-        XCTAssertTrue(session.sessionId > 0, @"Session id not greater than zero: %lld", session.sessionId);
-        
-        NSMutableArray<MPSession *> *sessions = [persistence fetchSessions];
-        MPSession *fetchedSession = [sessions lastObject];
-        XCTAssertEqualObjects(session, fetchedSession, @"Session and fetchedSession are not equal.");
-        
-        [persistence deleteSession:session];
-        
-        sessions = [persistence fetchSessions];
-        if (sessions) {
-            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"sessionId == %lld", fetchedSession.sessionId];
-            sessions = [NSMutableArray arrayWithArray:[sessions filteredArrayUsingPredicate:predicate]];
-            XCTAssertTrue(sessions.count == 0, @"Session is not being deleted.");
-        }
-        
-        [expectation fulfill];
-    });
+    MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
+    session.attributesDictionary = [@{@"key1":@"value1"} mutableCopy];
     
-    [self waitForExpectationsWithTimeout:DATABASE_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    MPPersistenceController *persistence = [MPPersistenceController sharedInstance];
+    [persistence saveSession:session];
+    
+    XCTAssertTrue(session.sessionId > 0, @"Session id not greater than zero: %lld", session.sessionId);
+    
+    NSMutableArray<MPSession *> *sessions = [persistence fetchSessions];
+    MPSession *fetchedSession = [sessions lastObject];
+    XCTAssertEqualObjects(session, fetchedSession, @"Session and fetchedSession are not equal.");
+    
+    [persistence deleteSession:session];
+    
+    sessions = [persistence fetchSessions];
+    if (sessions) {
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"sessionId == %lld", fetchedSession.sessionId];
+        sessions = [NSMutableArray arrayWithArray:[sessions filteredArrayUsingPredicate:predicate]];
+        XCTAssertTrue(sessions.count == 0, @"Session is not being deleted.");
+    }
 }
 
 - (void)testMessage {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Message test"];
-    
     [MPPersistenceController setMpid:@2];
     
-    dispatch_async(messageQueue, ^{
-        MPPersistenceController *persistence = [MPPersistenceController sharedInstance];
-        
-        MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
-        [persistence saveSession:session];
-        
-        MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                               session:session
-                                                                           messageInfo:@{@"MessageKey1":@"MessageValue1"}];
-        MPMessage *message = (MPMessage *)[messageBuilder build];
-        [persistence saveMessage:message];
-        
-        XCTAssertTrue(message.messageId > 0, @"Message id not greater than zero: %lld", message.messageId);
-        
-        NSDictionary *messagesDictionary = [persistence fetchMessagesForUploading];
-        NSMutableDictionary *sessionsDictionary = messagesDictionary[[MPPersistenceController mpId]];
-        NSArray<MPMessage *> *messages =  [sessionsDictionary objectForKey:[NSNumber numberWithLong:session.sessionId]];
-        MPMessage *fetchedMessage = [messages lastObject];
-        
-        XCTAssertEqualObjects(message, fetchedMessage, @"Message and fetchedMessage are not equal.");
-        
-        [persistence deleteSession:session];
-        
-        messagesDictionary = [persistence fetchMessagesForUploading];
-        messages = messagesDictionary[[MPPersistenceController mpId]];
-        if (messages) {
-            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"messageId == %lld", fetchedMessage.messageId];
-            messages = [messages filteredArrayUsingPredicate:predicate];
-            XCTAssertTrue(messages.count == 0, @"Message is not being deleted.");
-        }
-        
-        [expectation fulfill];
-    });
-    [self waitForExpectationsWithTimeout:DATABASE_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    MPPersistenceController *persistence = [MPPersistenceController sharedInstance];
+    
+    MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
+    [persistence saveSession:session];
+    
+    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
+                                                                           session:session
+                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessage *message = (MPMessage *)[messageBuilder build];
+    [persistence saveMessage:message];
+    
+    XCTAssertTrue(message.messageId > 0, @"Message id not greater than zero: %lld", message.messageId);
+    
+    NSDictionary *messagesDictionary = [persistence fetchMessagesForUploading];
+    NSMutableDictionary *sessionsDictionary = messagesDictionary[[MPPersistenceController mpId]];
+    NSArray<MPMessage *> *messages =  [sessionsDictionary objectForKey:[NSNumber numberWithLong:session.sessionId]];
+    MPMessage *fetchedMessage = [messages lastObject];
+    
+    XCTAssertEqualObjects(message, fetchedMessage, @"Message and fetchedMessage are not equal.");
+    
+    [persistence deleteSession:session];
+    
+    messagesDictionary = [persistence fetchMessagesForUploading];
+    messages = messagesDictionary[[MPPersistenceController mpId]];
+    if (messages) {
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"messageId == %lld", fetchedMessage.messageId];
+        messages = [messages filteredArrayUsingPredicate:predicate];
+        XCTAssertTrue(messages.count == 0, @"Message is not being deleted.");
+    }
 }
 
 - (void)testResetDatabase {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Message test"];
     
     [MPPersistenceController setMpid:@2];
     
-    dispatch_async(messageQueue, ^{
-        MPPersistenceController *persistence = [MPPersistenceController sharedInstance];
-        
-        MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
-        [persistence saveSession:session];
-        
-        MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                               session:session
-                                                                           messageInfo:@{@"MessageKey1":@"MessageValue1"}];
-        MPMessage *message = (MPMessage *)[messageBuilder build];
-        [persistence saveMessage:message];
-        
-        XCTAssertTrue(message.messageId > 0, @"Message id not greater than zero: %lld", message.messageId);
-        
-        NSDictionary *messagesDictionary = [persistence fetchMessagesForUploading];
-        NSMutableDictionary *sessionsDictionary = messagesDictionary[[MPPersistenceController mpId]];
-        NSArray<MPMessage *> *messages =  [sessionsDictionary objectForKey:[NSNumber numberWithLong:session.sessionId]];
-        MPMessage *fetchedMessage = [messages lastObject];
-        
-        XCTAssertEqualObjects(message, fetchedMessage, @"Message and fetchedMessage are not equal.");
-        
-        [[MPPersistenceController sharedInstance] resetDatabase];
-        
-        messagesDictionary = [persistence fetchMessagesForUploading];
-        messages = messagesDictionary[[MPPersistenceController mpId]];
-        if (messages) {
-            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"messageId == %lld", fetchedMessage.messageId];
-            messages = [messages filteredArrayUsingPredicate:predicate];
-            XCTAssertTrue(messages.count == 0, @"Message is not being deleted.");
-        }
-        
-        [expectation fulfill];
-    });
-    [self waitForExpectationsWithTimeout:DATABASE_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
-}
-
-- (void)testDeleteMessages {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Message test"];
+    MPPersistenceController *persistence = [MPPersistenceController sharedInstance];
     
-    [MPPersistenceController setMpid:@2];
-
-    dispatch_async(messageQueue, ^{
-        MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
-        MPPersistenceController *persistence = [MPPersistenceController sharedInstance];
-        
-        for (int i = 0; i < 10; ++i) {
-            NSString *key = [NSString stringWithFormat:@"Key%@", @(i)];
-            NSString *value = [NSString stringWithFormat:@"Value%@", @(i)];
-            
-            MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
-                                                                                   session:session
-                                                                               messageInfo:@{key:value}];
-            MPMessage *message = (MPMessage *)[messageBuilder build];
-            [persistence saveMessage:message];
-        }
-        
-        NSDictionary *messagesDictionary = [persistence fetchMessagesForUploading];
-        NSMutableDictionary *sessionsDictionary = messagesDictionary[[MPPersistenceController mpId]];
-        NSArray *messages =  [sessionsDictionary objectForKey:[NSNumber numberWithLong:session.sessionId]];
-        [persistence deleteMessages:messages];
-        
-        messagesDictionary = [persistence fetchMessagesForUploading];
-        messages = messagesDictionary[[MPPersistenceController mpId]];
-        XCTAssertNil(messages, @"Should have been nil.");
-        
-        [expectation fulfill];
-    });
+    MPSession *session = [[MPSession alloc] initWithStartTime:[[NSDate date] timeIntervalSince1970] userId:[MPPersistenceController mpId]];
+    [persistence saveSession:session];
     
-    [self waitForExpectationsWithTimeout:DATABASE_TESTS_EXPECTATIONS_TIMEOUT handler:nil];
+    MPMessageBuilder *messageBuilder = [MPMessageBuilder newBuilderWithMessageType:MPMessageTypeEvent
+                                                                           session:session
+                                                                       messageInfo:@{@"MessageKey1":@"MessageValue1"}];
+    MPMessage *message = (MPMessage *)[messageBuilder build];
+    [persistence saveMessage:message];
+    
+    XCTAssertTrue(message.messageId > 0, @"Message id not greater than zero: %lld", message.messageId);
+    
+    NSDictionary *messagesDictionary = [persistence fetchMessagesForUploading];
+    NSMutableDictionary *sessionsDictionary = messagesDictionary[[MPPersistenceController mpId]];
+    NSArray<MPMessage *> *messages =  [sessionsDictionary objectForKey:[NSNumber numberWithLong:session.sessionId]];
+    MPMessage *fetchedMessage = [messages lastObject];
+    
+    XCTAssertEqualObjects(message, fetchedMessage, @"Message and fetchedMessage are not equal.");
+    
+    [[MPPersistenceController sharedInstance] resetDatabase];
+    
+    messagesDictionary = [persistence fetchMessagesForUploading];
+    messages = messagesDictionary[[MPPersistenceController mpId]];
+    if (messages) {
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"messageId == %lld", fetchedMessage.messageId];
+        messages = [messages filteredArrayUsingPredicate:predicate];
+        XCTAssertTrue(messages.count == 0, @"Message is not being deleted.");
+    }
+    
 }
 
 - (void)testUpload {
@@ -286,7 +222,7 @@
 
 - (void)testSegments {
     [MPPersistenceController setMpid:@2];
-
+    
     NSDictionary *segmentDictionary = @{@"id":@2,
                                         @"n":@"External Name 101",
                                         @"c":@[@{@"ct":@1395014265365,
@@ -422,15 +358,9 @@
     [persistence saveConsumerInfo:consumerInfo];
     [persistence updateConsumerInfo:consumerInfo];
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Consumer Info"];
-    
     consumerInfo = [persistence fetchConsumerInfoForUserId:[MPPersistenceController mpId]];
     XCTAssertNotNil(consumerInfo);
     [persistence deleteConsumerInfo];
-    
-    [expectation fulfill];
-    
-    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testForwardRecord {
@@ -457,7 +387,7 @@
                                                                    messages:@[]
                                                              sessionTimeout:DEFAULT_SESSION_TIMEOUT
                                                              uploadInterval:DEFAULT_DEBUG_UPLOAD_INTERVAL];
-
+    
     [uploadBuilder build: ^(MPUpload * _Nullable upload) {
     }];
     

--- a/UnitTests/MPURLRequestBuilderTests.m
+++ b/UnitTests/MPURLRequestBuilderTests.m
@@ -11,6 +11,13 @@
 #import "MPIUserDefaults.h"
 #import "MPPersistenceController.h"
 #import "MPMessage.h"
+#import "MPKitInstanceValidator.h"
+
+@interface MPKitInstanceValidator ()
+
++ (void)includeUnitTestKits:(NSArray<NSNumber *> *)kitCodes;
+
+@end
 
 #pragma mark - MPURLRequestBuilder category
 @interface MPURLRequestBuilder(Tests)
@@ -31,6 +38,8 @@
 
 - (void)setUp {
     [super setUp];
+    
+    [MPKitInstanceValidator includeUnitTestKits:@[@42]];
     
     MPStateMachine *stateMachine = [MPStateMachine sharedInstance];
     stateMachine.apiKey = @"unit_test_app_key";

--- a/mParticle-Apple-SDK.podspec
+++ b/mParticle-Apple-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-Apple-SDK"
-    s.version          = "7.3.9"
+    s.version          = "7.4.1"
     s.summary          = "mParticle Apple SDK."
 
     s.description      = <<-DESC
@@ -49,7 +49,7 @@ Pod::Spec.new do |s|
         ss.source_files         = 'mParticle-Apple-SDK/**/*'
         ss.libraries            = 'c++', 'sqlite3', 'z'
 
-        ss.ios.frameworks       = 'Accounts', 'AdSupport', 'CoreGraphics', 'CoreLocation', 'CoreTelephony', 'Foundation', 'Security', 'Social', 'SystemConfiguration', 'UIKit'
+        ss.ios.frameworks       = 'AdSupport', 'CoreGraphics', 'CoreLocation', 'CoreTelephony', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
         ss.ios.weak_frameworks  = 'iAd', 'UserNotifications'
 
         ss.tvos.frameworks      = 'AdSupport', 'CoreGraphics', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
@@ -62,7 +62,7 @@ Pod::Spec.new do |s|
         ext.source_files         = 'mParticle-Apple-SDK/**/*'
         ext.libraries            = 'c++', 'sqlite3', 'z'
 
-        ext.ios.frameworks       = 'Accounts', 'AdSupport', 'CoreGraphics', 'CoreLocation', 'CoreTelephony', 'Foundation', 'Security', 'Social', 'SystemConfiguration', 'UIKit'
+        ext.ios.frameworks       = 'AdSupport', 'CoreGraphics', 'CoreLocation', 'CoreTelephony', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
         ext.ios.weak_frameworks  = 'iAd', 'UserNotifications'
 
         ext.tvos.frameworks      = 'AdSupport', 'CoreGraphics', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'

--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -382,7 +382,6 @@
 		C9DD20631D8A142900D3ABBE /* MPIHasher.mm in Sources */ = {isa = PBXBuildFile; fileRef = C9DD1CFA1D8A112B00D3ABBE /* MPIHasher.mm */; };
 		C9DD20641D8A142900D3ABBE /* MPUserSegments.h in Headers */ = {isa = PBXBuildFile; fileRef = C9DD1CFB1D8A112B00D3ABBE /* MPUserSegments.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C9DD20651D8A142900D3ABBE /* MPUserSegments.m in Sources */ = {isa = PBXBuildFile; fileRef = C9DD1CFC1D8A112B00D3ABBE /* MPUserSegments.m */; };
-		C9DD20681D8A146900D3ABBE /* Accounts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD20671D8A146900D3ABBE /* Accounts.framework */; };
 		C9DD206A1D8A146F00D3ABBE /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD20691D8A146F00D3ABBE /* AdSupport.framework */; };
 		C9DD206C1D8A147A00D3ABBE /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD206B1D8A147A00D3ABBE /* UIKit.framework */; };
 		C9DD206E1D8A148400D3ABBE /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD206D1D8A148400D3ABBE /* SystemConfiguration.framework */; };
@@ -700,7 +699,6 @@
 		C9DD1D371D8A112B00D3ABBE /* NSString+MPPercentEscape.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+MPPercentEscape.h"; sourceTree = "<group>"; };
 		C9DD1D381D8A112B00D3ABBE /* NSString+MPPercentEscape.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+MPPercentEscape.m"; sourceTree = "<group>"; };
 		C9DD1DFF1D8A118400D3ABBE /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Apple_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C9DD20671D8A146900D3ABBE /* Accounts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accounts.framework; path = System/Library/Frameworks/Accounts.framework; sourceTree = SDKROOT; };
 		C9DD20691D8A146F00D3ABBE /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		C9DD206B1D8A147A00D3ABBE /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		C9DD206D1D8A148400D3ABBE /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -839,7 +837,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C9DD20681D8A146900D3ABBE /* Accounts.framework in Frameworks */,
 				C9DD206A1D8A146F00D3ABBE /* AdSupport.framework in Frameworks */,
 				C9DD20801D8A14E200D3ABBE /* CoreGraphics.framework in Frameworks */,
 				C9DD207E1D8A14D800D3ABBE /* CoreLocation.framework in Frameworks */,
@@ -1228,7 +1225,6 @@
 				C9DD206D1D8A148400D3ABBE /* SystemConfiguration.framework */,
 				C9DD206B1D8A147A00D3ABBE /* UIKit.framework */,
 				C9DD20691D8A146F00D3ABBE /* AdSupport.framework */,
-				C9DD20671D8A146900D3ABBE /* Accounts.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1642,8 +1638,7 @@
 				TargetAttributes = {
 					C911FD7B1D8A3524002A3516 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = DLD43Y3TRP;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					C935A6B21D8A2B6B00A1EE2F = {
 						CreatedOnToolsVersion = 8.0;
@@ -1657,8 +1652,7 @@
 					};
 					C9DD20841D8A18F500D3ABBE = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = DLD43Y3TRP;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -2034,7 +2028,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				DEVELOPMENT_TEAM = DLD43Y3TRP;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = UnitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
@@ -2044,6 +2039,7 @@
 				MACH_O_TYPE = mh_dylib;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-tvOS-SDKTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -2054,7 +2050,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				DEVELOPMENT_TEAM = DLD43Y3TRP;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = UnitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
@@ -2064,6 +2061,7 @@
 				MACH_O_TYPE = mh_dylib;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-tvOS-SDKTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -2285,7 +2283,8 @@
 		C9DD208E1D8A18F600D3ABBE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DEVELOPMENT_TEAM = DLD43Y3TRP;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/UnitTests/Libraries";
 				INFOPLIST_FILE = UnitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -2298,13 +2297,15 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-iOS-SDKTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug;
 		};
 		C9DD208F1D8A18F600D3ABBE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DEVELOPMENT_TEAM = DLD43Y3TRP;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/UnitTests/Libraries";
 				INFOPLIST_FILE = UnitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -2316,6 +2317,7 @@
 				MACH_O_TYPE = mh_dylib;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-iOS-SDKTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;
 		};

--- a/mParticle-Apple-SDK/AppNotifications/MPSurrogateAppDelegate.m
+++ b/mParticle-Apple-SDK/AppNotifications/MPSurrogateAppDelegate.m
@@ -2,6 +2,7 @@
 #import "MPAppDelegateProxy.h"
 #import "MPNotificationController.h"
 #import "MPAppNotificationHandler.h"
+#import "MPStateMachine.h"
 
 @implementation MPSurrogateAppDelegate
 
@@ -11,9 +12,10 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification {
     NSDictionary *userInfo;
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-    userInfo = [MPNotificationController dictionaryFromLocalNotification:notification];
-#endif
+    if (![MPStateMachine isAppExtension]) {
+        userInfo = [MPNotificationController dictionaryFromLocalNotification:notification];
+    }
+
     if (userInfo) {
         [[MPAppNotificationHandler sharedInstance] receivedUserNotification:userInfo actionIdentifier:nil userNotificationMode:MPUserNotificationModeLocal];
     }
@@ -74,9 +76,10 @@
 
 - (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification completionHandler:(void (^)())completionHandler {
     NSDictionary *userInfo;
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-    userInfo = [MPNotificationController dictionaryFromLocalNotification:notification];
-#endif
+    if (![MPStateMachine isAppExtension]) {
+        userInfo = [MPNotificationController dictionaryFromLocalNotification:notification];
+    }
+
     if (userInfo) {
         [[MPAppNotificationHandler sharedInstance] receivedUserNotification:userInfo actionIdentifier:identifier userNotificationMode:MPUserNotificationModeLocal];
     }

--- a/mParticle-Apple-SDK/Data Model/MPMessage.h
+++ b/mParticle-Apple-SDK/Data Model/MPMessage.h
@@ -4,7 +4,7 @@
 
 @class MPSession;
 
-@interface MPMessage : MPDataModelAbstract <NSCopying, MPDataModelProtocol>
+@interface MPMessage : MPDataModelAbstract <NSCopying, NSCoding, MPDataModelProtocol>
 
 @property (nonatomic, strong, readonly, nonnull) NSString *messageType;
 @property (nonatomic, strong, readonly, nonnull) NSData *messageData;

--- a/mParticle-Apple-SDK/Data Model/MPMessage.m
+++ b/mParticle-Apple-SDK/Data Model/MPMessage.m
@@ -80,6 +80,31 @@
     return copyObject;
 }
 
+#pragma mark NSCoding
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [coder encodeObject:self.sessionId forKey:@"sessionId"];
+    [coder encodeInt64:self.messageId forKey:@"messageId"];
+    [coder encodeObject:self.uuid forKey:@"uuid"];
+    [coder encodeObject:self.messageType forKey:@"messageType"];
+    [coder encodeObject:self.messageData forKey:@"messageData"];
+    [coder encodeDouble:self.timestamp forKey:@"timestamp"];
+    [coder encodeInteger:self.uploadStatus forKey:@"uploadStatus"];
+    [coder encodeInt64:_userId.longLongValue forKey:@"mpid"];
+}
+
+- (id)initWithCoder:(NSCoder *)coder {
+    self = [self initWithSessionId:[coder decodeObjectForKey:@"sessionId"]
+                         messageId:[coder decodeInt64ForKey:@"messageId"]
+                              UUID:[coder decodeObjectForKey:@"uuid"]
+                       messageType:[coder decodeObjectForKey:@"messageType"]
+                       messageData:[coder decodeObjectForKey:@"messageData"]
+                         timestamp:[coder decodeDoubleForKey:@"timestamp"]
+                      uploadStatus:[coder decodeIntegerForKey:@"uploadStatus"]
+                            userId:@([coder decodeInt64ForKey:@"mpid"])];
+    
+    return self;
+}
+
 #pragma mark Public methods
 - (NSDictionary *)dictionaryRepresentation {
     NSError *error = nil;

--- a/mParticle-Apple-SDK/Data Model/MParticleUserNotification.h
+++ b/mParticle-Apple-SDK/Data Model/MParticleUserNotification.h
@@ -24,7 +24,6 @@ extern NSString * _Nonnull const kMPUserNotificationCategoryKey;
 
 #if TARGET_OS_IOS == 1
 
-NS_EXTENSION_UNAVAILABLE_IOS("")
 @interface MParticleUserNotification : MPDataModelAbstract <NSCoding>
 
 @property (nonatomic, strong, nullable) NSString *actionIdentifier;

--- a/mParticle-Apple-SDK/Data Model/MParticleUserNotification.m
+++ b/mParticle-Apple-SDK/Data Model/MParticleUserNotification.m
@@ -1,4 +1,5 @@
 #import "MParticleUserNotification.h"
+#import "MPApplication.h"
 
 NSString *const kMPUserNotificationApsKey = @"aps";
 NSString *const kMPUserNotificationAlertKey = @"alert";
@@ -45,10 +46,10 @@ NSString *const kMPUserNotificationCategoryKey = @"category";
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
             __block UIUserNotificationSettings *userNotificationSettings = nil;
             if ([NSThread isMainThread]) {
-                userNotificationSettings = [[UIApplication sharedApplication] currentUserNotificationSettings];
+                userNotificationSettings = [[MPApplication sharedUIApplication] currentUserNotificationSettings];
             } else {
                 dispatch_sync(dispatch_get_main_queue(), ^{
-                    userNotificationSettings = [[UIApplication sharedApplication] currentUserNotificationSettings];
+                    userNotificationSettings = [[MPApplication sharedUIApplication] currentUserNotificationSettings];
                 });
             }
             

--- a/mParticle-Apple-SDK/Ecommerce/MPCart.m
+++ b/mParticle-Apple-SDK/Ecommerce/MPCart.m
@@ -121,7 +121,12 @@
         return nil;
     }
     
-    MPCart *cart = (MPCart *)[NSKeyedUnarchiver unarchiveObjectWithFile:_cartFile];
+    MPCart *cart;
+    @try {
+        cart = (MPCart *)[NSKeyedUnarchiver unarchiveObjectWithFile:_cartFile];
+    } @catch(NSException *ex) {
+        MPILogger(MPILogLevelError, @"Failed To retrieve cart: %@", ex);
+    }
     return cart;
 }
 

--- a/mParticle-Apple-SDK/Identity/MPIdentityApi.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityApi.m
@@ -45,7 +45,7 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
 
 @interface MParticleUser ()
 
-- (void)setUserIdentity:(NSString *)identityString identityType:(MPUserIdentity)identityType;
+- (void)setUserIdentitySync:(NSString *)identityString identityType:(MPUserIdentity)identityType;
 - (void)setUserId:(NSNumber *)userId;
 @end
 
@@ -81,17 +81,19 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
             if ((NSNull *)identityValue == [NSNull null]) {
                 identityValue = nil;
             }
-            [self.currentUser setUserIdentity:identityValue identityType:identityType];
+            [self.currentUser setUserIdentitySync:identityValue identityType:identityType];
         }];
     }
     
     // Forward call to kits
-    [[MPKitContainer sharedInstance] forwardIdentitySDKCall:@selector(onModifyComplete: request:)
-                                                 kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
-                                                     FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:self.currentUser kitConfiguration:kitConfig];
-                                                     FilteredMPIdentityApiRequest *filteredRequest = [[FilteredMPIdentityApiRequest alloc] initWithIdentityRequest:request kitConfiguration:kitConfig];
-                                                     [kit onModifyComplete:filteredUser request:filteredRequest];
-                                                 }];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[MPKitContainer sharedInstance] forwardIdentitySDKCall:@selector(onModifyComplete: request:)
+                                                     kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
+                                                         FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:self.currentUser kitConfiguration:kitConfig];
+                                                         FilteredMPIdentityApiRequest *filteredRequest = [[FilteredMPIdentityApiRequest alloc] initWithIdentityRequest:request kitConfiguration:kitConfig];
+                                                         [kit onModifyComplete:filteredUser request:filteredRequest];
+                                                     }];
+    });
     
     if (completion) {
         MPIdentityApiResult *apiResult = [[MPIdentityApiResult alloc] init];
@@ -138,7 +140,7 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
     if (request.userIdentities) {
         [request.userIdentities enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull key, id  _Nonnull identityValue, BOOL * _Nonnull stop) {
             MPUserIdentity identityType = (MPUserIdentity)key.intValue;
-            [self.currentUser setUserIdentity:identityValue identityType:identityType];
+            [self.currentUser setUserIdentitySync:identityValue identityType:identityType];
         }];
     }
     
@@ -164,57 +166,63 @@ typedef NS_ENUM(NSUInteger, MPIdentityRequestType) {
     
     if (user) {
         NSDictionary *userInfo = @{mParticleUserKey:user};
-        [[NSNotificationCenter defaultCenter] postNotificationName:mParticleIdentityStateChangeListenerNotification object:nil userInfo:userInfo];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:mParticleIdentityStateChangeListenerNotification object:nil userInfo:userInfo];
+        });
     }
     
     NSArray<NSDictionary *> *kitConfig = [[MPKitContainer sharedInstance].originalConfig copy];
     if (kitConfig) {
-        [[MPKitContainer sharedInstance] configureKits:kitConfig];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[MPKitContainer sharedInstance] configureKits:kitConfig];
+        });
     }
     
     // Forwarding calls to kits
-    switch (identityRequestType) {
-        case MPIdentityRequestIdentify: {
-            [[MPKitContainer sharedInstance] forwardIdentitySDKCall:@selector(onIdentifyComplete: request:)
-                                                         kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
-                                                             FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:user kitConfiguration:kitConfig];
-                                                             FilteredMPIdentityApiRequest *filteredRequest = [[FilteredMPIdentityApiRequest alloc] initWithIdentityRequest:request kitConfiguration:kitConfig];
-                                                             [kit onIdentifyComplete:filteredUser request:filteredRequest];
-                                                         }];
-            break;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        switch (identityRequestType) {
+            case MPIdentityRequestIdentify: {
+                [[MPKitContainer sharedInstance] forwardIdentitySDKCall:@selector(onIdentifyComplete: request:)
+                                                             kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
+                                                                 FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:user kitConfiguration:kitConfig];
+                                                                 FilteredMPIdentityApiRequest *filteredRequest = [[FilteredMPIdentityApiRequest alloc] initWithIdentityRequest:request kitConfiguration:kitConfig];
+                                                                 [kit onIdentifyComplete:filteredUser request:filteredRequest];
+                                                             }];
+                break;
+            }
+            case MPIdentityRequestLogin: {
+                [[MPKitContainer sharedInstance] forwardIdentitySDKCall:@selector(onLoginComplete: request:)
+                                                             kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
+                                                                 FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:user kitConfiguration:kitConfig];
+                                                                 FilteredMPIdentityApiRequest *filteredRequest = [[FilteredMPIdentityApiRequest alloc] initWithIdentityRequest:request kitConfiguration:kitConfig];
+                                                                 [kit onLoginComplete:filteredUser request:filteredRequest];
+                                                             }];
+                break;
+            }
+            case MPIdentityRequestLogout: {
+                [[MPKitContainer sharedInstance] forwardIdentitySDKCall:@selector(onLogoutComplete: request:)
+                                                             kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
+                                                                 FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:user kitConfiguration:kitConfig];
+                                                                 FilteredMPIdentityApiRequest *filteredRequest = [[FilteredMPIdentityApiRequest alloc] initWithIdentityRequest:request kitConfiguration:kitConfig];
+                                                                 [kit onLogoutComplete:filteredUser request:filteredRequest];
+                                                             }];
+                break;
+            }
+            case MPIdentityRequestModify: {
+                [[MPKitContainer sharedInstance] forwardIdentitySDKCall:@selector(onModifyComplete: request:)
+                                                             kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
+                                                                 FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:user kitConfiguration:kitConfig];
+                                                                 FilteredMPIdentityApiRequest *filteredRequest = [[FilteredMPIdentityApiRequest alloc] initWithIdentityRequest:request kitConfiguration:kitConfig];
+                                                                 [kit onModifyComplete:filteredUser request:filteredRequest];
+                                                             }];
+                break;
+            }
+            default: {
+                MPILogError(@"Unknown identity request type: %@", @(identityRequestType));
+                break;
+            }
         }
-        case MPIdentityRequestLogin: {
-            [[MPKitContainer sharedInstance] forwardIdentitySDKCall:@selector(onLoginComplete: request:)
-                                                         kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
-                                                             FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:user kitConfiguration:kitConfig];
-                                                             FilteredMPIdentityApiRequest *filteredRequest = [[FilteredMPIdentityApiRequest alloc] initWithIdentityRequest:request kitConfiguration:kitConfig];
-                                                             [kit onLoginComplete:filteredUser request:filteredRequest];
-                                                         }];
-            break;
-        }
-        case MPIdentityRequestLogout: {
-            [[MPKitContainer sharedInstance] forwardIdentitySDKCall:@selector(onLogoutComplete: request:)
-                                                         kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
-                                                             FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:user kitConfiguration:kitConfig];
-                                                             FilteredMPIdentityApiRequest *filteredRequest = [[FilteredMPIdentityApiRequest alloc] initWithIdentityRequest:request kitConfiguration:kitConfig];
-                                                             [kit onLogoutComplete:filteredUser request:filteredRequest];
-                                                         }];
-            break;
-        }
-        case MPIdentityRequestModify: {
-            [[MPKitContainer sharedInstance] forwardIdentitySDKCall:@selector(onModifyComplete: request:)
-                                                         kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
-                                                             FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:user kitConfiguration:kitConfig];
-                                                             FilteredMPIdentityApiRequest *filteredRequest = [[FilteredMPIdentityApiRequest alloc] initWithIdentityRequest:request kitConfiguration:kitConfig];
-                                                             [kit onModifyComplete:filteredUser request:filteredRequest];
-                                                         }];
-            break;
-        }
-        default: {
-            MPILogError(@"Unknown identity request type: %@", @(identityRequestType));
-            break;
-        }
-    }
+    });
     
     if (completion) {
         completion(apiResult, nil);

--- a/mParticle-Apple-SDK/Identity/MPIdentityApiRequest.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityApiRequest.m
@@ -6,6 +6,7 @@
 #import "MPDevice.h"
 #import "MPNotificationController.h"
 #import "MPIConstants.h"
+#import "MPStateMachine.h"
 
 @implementation MPIdentityApiRequest
 
@@ -114,12 +115,12 @@
     }
     
 #if TARGET_OS_IOS == 1
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-    NSString *deviceToken = [[NSString alloc] initWithData:[MPNotificationController deviceToken] encoding:NSUTF8StringEncoding];
-    if (deviceToken && [deviceToken length] > 0) {
-        knownIdentities[@"push_token"] = deviceToken;
+    if (![MPStateMachine isAppExtension]) {
+        NSString *deviceToken = [[NSString alloc] initWithData:[MPNotificationController deviceToken] encoding:NSUTF8StringEncoding];
+        if (deviceToken && [deviceToken length] > 0) {
+            knownIdentities[@"push_token"] = deviceToken;
+        }
     }
-#endif
 #endif
     
     return knownIdentities;

--- a/mParticle-Apple-SDK/Identity/MPIdentityDTO.m
+++ b/mParticle-Apple-SDK/Identity/MPIdentityDTO.m
@@ -70,12 +70,12 @@
         }
         
 #if TARGET_OS_IOS == 1
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-        NSString *deviceToken = [[NSString alloc] initWithData:[MPNotificationController deviceToken] encoding:NSUTF8StringEncoding];
-        if (deviceToken) {
-            _knownIdentities.pushToken = deviceToken;
+        if (![MPStateMachine isAppExtension]) {
+            NSString *deviceToken = [[NSString alloc] initWithData:[MPNotificationController deviceToken] encoding:NSUTF8StringEncoding];
+            if (deviceToken) {
+                _knownIdentities.pushToken = deviceToken;
+            }
         }
-#endif
 #endif
     }
     return self;

--- a/mParticle-Apple-SDK/Identity/MParticleUser.m
+++ b/mParticle-Apple-SDK/Identity/MParticleUser.m
@@ -22,6 +22,7 @@
 @interface MParticle ()
 
 + (dispatch_queue_t)messageQueue;
++ (dispatch_queue_t)networkQueue;
 @property (nonatomic, strong) MPBackendController *backendController;
 
 @end
@@ -109,24 +110,34 @@
     
     NSDate *timestamp = [NSDate date];
     dispatch_async([MParticle messageQueue], ^{
-        [self.backendController setUserIdentity:identityString
-                                   identityType:identityType
-                                      timestamp:timestamp
-                              completionHandler:^(NSString *identityString, MPUserIdentity identityType, MPExecStatus execStatus) {
+        [self setUserIdentitySync:identityString identityType:identityType timestamp:timestamp];
+    });
+}
+
+- (void)setUserIdentitySync:(NSString *)identityString identityType:(MPUserIdentity)identityType {
+    [self setUserIdentitySync:identityString identityType:identityType timestamp:[NSDate date]];
+}
+
+- (void)setUserIdentitySync:(NSString *)identityString identityType:(MPUserIdentity)identityType timestamp:(NSDate *)timestamp {
+    [self.backendController setUserIdentity:identityString
+                               identityType:identityType
+                                  timestamp:timestamp
+                          completionHandler:^(NSString *identityString, MPUserIdentity identityType, MPExecStatus execStatus) {
+                              
+                              if (execStatus == MPExecStatusSuccess) {
+                                  MPILogDebug(@"Set user identity: %@", identityString);
                                   
-                                  if (execStatus == MPExecStatusSuccess) {
-                                      MPILogDebug(@"Set user identity: %@", identityString);
-                                      
-                                      // Forwarding calls to kits
+                                  // Forwarding calls to kits
+                                  dispatch_async(dispatch_get_main_queue(), ^{
                                       [[MPKitContainer sharedInstance] forwardSDKCall:@selector(setUserIdentity:identityType:)
                                                                          userIdentity:identityString
                                                                          identityType:identityType
                                                                            kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
                                                                                [kit setUserIdentity:identityString identityType:identityType];
                                                                            }];
-                                  }
-                              }];
-    });
+                                  });
+                              }
+                          }];
 }
 
 - (nullable NSNumber *)incrementUserAttribute:(NSString *)key byValue:(NSNumber *)value {
@@ -140,36 +151,37 @@
         NSNumber *newValue = [self.backendController incrementUserAttribute:key byValue:value];
         
         MPILogDebug(@"User attribute %@ incremented by %@. New value: %@", key, value, newValue);
-        
-        [[MPKitContainer sharedInstance] forwardSDKCall:@selector(incrementUserAttribute:byValue:)
-                                       userAttributeKey:key
-                                                  value:value
-                                             kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
-                                                 FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:self kitConfiguration:kitConfig];
-                                                 
-                                                 if ([kit respondsToSelector:@selector(incrementUserAttribute:byValue:)]) {
-                                                     [kit incrementUserAttribute:key byValue:value];
-                                                 }
-                                                 if ([kit respondsToSelector:@selector(onIncrementUserAttribute:)] && filteredUser != nil) {
-                                                     [kit onIncrementUserAttribute:filteredUser];
-                                                 }
-                                             }];
-        
-        [[MPKitContainer sharedInstance] forwardSDKCall:@selector(setUserAttribute:value:)
-                                       userAttributeKey:key
-                                                  value:newValue
-                                             kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
-                                                 if (![kit respondsToSelector:@selector(incrementUserAttribute:byValue:)]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[MPKitContainer sharedInstance] forwardSDKCall:@selector(incrementUserAttribute:byValue:)
+                                           userAttributeKey:key
+                                                      value:value
+                                                 kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
                                                      FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:self kitConfiguration:kitConfig];
                                                      
-                                                     if ([kit respondsToSelector:@selector(setUserAttribute:value:)]) {
-                                                         [kit setUserAttribute:key value:newValue];
+                                                     if ([kit respondsToSelector:@selector(incrementUserAttribute:byValue:)]) {
+                                                         [kit incrementUserAttribute:key byValue:value];
                                                      }
-                                                     if ([kit respondsToSelector:@selector(onSetUserAttribute:)] && filteredUser != nil) {
-                                                         [kit onSetUserAttribute:filteredUser];
+                                                     if ([kit respondsToSelector:@selector(onIncrementUserAttribute:)] && filteredUser != nil) {
+                                                         [kit onIncrementUserAttribute:filteredUser];
                                                      }
-                                                 }
-                                             }];
+                                                 }];
+            
+            [[MPKitContainer sharedInstance] forwardSDKCall:@selector(setUserAttribute:value:)
+                                           userAttributeKey:key
+                                                      value:newValue
+                                                 kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
+                                                     if (![kit respondsToSelector:@selector(incrementUserAttribute:byValue:)]) {
+                                                         FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:self kitConfiguration:kitConfig];
+                                                         
+                                                         if ([kit respondsToSelector:@selector(setUserAttribute:value:)]) {
+                                                             [kit setUserAttribute:key value:newValue];
+                                                         }
+                                                         if ([kit respondsToSelector:@selector(onSetUserAttribute:)] && filteredUser != nil) {
+                                                             [kit onSetUserAttribute:filteredUser];
+                                                         }
+                                                     }
+                                                 }];
+        });
     });
     
     return @0;
@@ -198,19 +210,20 @@
                                        } else {
                                            MPILogDebug(@"Reset user attribute - %@", key);
                                        }
-                                       
-                                       // Forwarding calls to kits
-                                       [[MPKitContainer sharedInstance] forwardSDKCall:@selector(setUserAttribute:value:)
-                                                                      userAttributeKey:key
-                                                                                 value:value
-                                                                            kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
-                                                                                FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:strongSelf kitConfiguration:kitConfig];
-                                                                                
-                                                                                [kit setUserAttribute:key value:value];
-                                                                                if ([kit respondsToSelector:@selector(onSetUserAttribute:)] && filteredUser != nil) {
-                                                                                    [kit onSetUserAttribute:filteredUser];
-                                                                                }
-                                                                            }];
+                                       dispatch_async(dispatch_get_main_queue(), ^{
+                                           // Forwarding calls to kits
+                                           [[MPKitContainer sharedInstance] forwardSDKCall:@selector(setUserAttribute:value:)
+                                                                          userAttributeKey:key
+                                                                                     value:value
+                                                                                kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
+                                                                                    FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:strongSelf kitConfiguration:kitConfig];
+                                                                                    
+                                                                                    [kit setUserAttribute:key value:value];
+                                                                                    if ([kit respondsToSelector:@selector(onSetUserAttribute:)] && filteredUser != nil) {
+                                                                                        [kit onSetUserAttribute:filteredUser];
+                                                                                    }
+                                                                                }];
+                                        });
                                    }
                                }];
     });
@@ -241,23 +254,25 @@
                                        }
                                        
                                        // Forwarding calls to kits
-                                       SEL setUserAttributeSelector = @selector(setUserAttribute:value:);
-                                       SEL setUserAttributeListSelector = @selector(setUserAttribute:values:);
-                                       
-                                       [[MPKitContainer sharedInstance] forwardSDKCall:setUserAttributeListSelector
-                                                                      userAttributeKey:key
-                                                                                 value:values
-                                                                            kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
-                                                                                FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:strongSelf kitConfiguration:kitConfig];
-                                                                                if ([kit respondsToSelector:setUserAttributeListSelector]) {
-                                                                                    [kit setUserAttribute:key values:values];
-                                                                                } else if ([kit respondsToSelector:setUserAttributeSelector]) {
-                                                                                    NSString *csvValues = [values componentsJoinedByString:@","];
-                                                                                    [kit setUserAttribute:key value:csvValues];
-                                                                                } else if ([kit respondsToSelector:@selector(onSetUserAttribute:)] && filteredUser != nil) {
-                                                                                    [kit onSetUserAttribute:filteredUser];
-                                                                                }
-                                                                            }];
+                                       dispatch_async(dispatch_get_main_queue(), ^{
+                                           SEL setUserAttributeSelector = @selector(setUserAttribute:value:);
+                                           SEL setUserAttributeListSelector = @selector(setUserAttribute:values:);
+                                           
+                                           [[MPKitContainer sharedInstance] forwardSDKCall:setUserAttributeListSelector
+                                                                          userAttributeKey:key
+                                                                                     value:values
+                                                                                kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
+                                                                                    FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:strongSelf kitConfiguration:kitConfig];
+                                                                                    if ([kit respondsToSelector:setUserAttributeListSelector]) {
+                                                                                        [kit setUserAttribute:key values:values];
+                                                                                    } else if ([kit respondsToSelector:setUserAttributeSelector]) {
+                                                                                        NSString *csvValues = [values componentsJoinedByString:@","];
+                                                                                        [kit setUserAttribute:key value:csvValues];
+                                                                                    } else if ([kit respondsToSelector:@selector(onSetUserAttribute:)] && filteredUser != nil) {
+                                                                                        [kit onSetUserAttribute:filteredUser];
+                                                                                    }
+                                                                                }];
+                                       });
                                    }
                                }];
     });
@@ -277,17 +292,19 @@
                                        MPILogDebug(@"Set user tag - %@", tag);
                                        
                                        // Forwarding calls to kits
-                                       [[MPKitContainer sharedInstance] forwardSDKCall:@selector(setUserTag:)
-                                                                      userAttributeKey:tag
-                                                                                 value:nil
-                                                                            kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
-                                                                                FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:strongSelf kitConfiguration:kitConfig];
-                                                                                
-                                                                                [kit setUserTag:tag];
-                                                                                if ([kit respondsToSelector:@selector(onSetUserTag:)] && filteredUser != nil) {
-                                                                                    [kit onSetUserTag:filteredUser];
-                                                                                }
-                                                                            }];
+                                       dispatch_async(dispatch_get_main_queue(), ^{
+                                           [[MPKitContainer sharedInstance] forwardSDKCall:@selector(setUserTag:)
+                                                                          userAttributeKey:tag
+                                                                                     value:nil
+                                                                                kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
+                                                                                    FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:strongSelf kitConfiguration:kitConfig];
+                                                                                    
+                                                                                    [kit setUserTag:tag];
+                                                                                    if ([kit respondsToSelector:@selector(onSetUserTag:)] && filteredUser != nil) {
+                                                                                        [kit onSetUserTag:filteredUser];
+                                                                                    }
+                                                                                }];
+                                        });
                                    }
                                }];
     });
@@ -307,17 +324,19 @@
                                        MPILogDebug(@"Removed user attribute - %@", key);
                                        
                                        // Forwarding calls to kits
-                                       [[MPKitContainer sharedInstance] forwardSDKCall:_cmd
-                                                                      userAttributeKey:key
-                                                                                 value:nil
-                                                                            kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
-                                                                                FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:strongSelf kitConfiguration:kitConfig];
-                                                                                
-                                                                                [kit removeUserAttribute:key];
-                                                                                if ([kit respondsToSelector:@selector(onRemoveUserAttribute:)] && filteredUser != nil) {
-                                                                                    [kit onRemoveUserAttribute:filteredUser];
-                                                                                }
-                                                                            }];
+                                       dispatch_async(dispatch_get_main_queue(), ^{
+                                           [[MPKitContainer sharedInstance] forwardSDKCall:_cmd
+                                                                          userAttributeKey:key
+                                                                                     value:nil
+                                                                                kitHandler:^(id<MPKitProtocol> kit, MPKitConfiguration *kitConfig) {
+                                                                                    FilteredMParticleUser *filteredUser = [[FilteredMParticleUser alloc] initWithMParticleUser:strongSelf kitConfiguration:kitConfig];
+                                                                                    
+                                                                                    [kit removeUserAttribute:key];
+                                                                                    if ([kit respondsToSelector:@selector(onRemoveUserAttribute:)] && filteredUser != nil) {
+                                                                                        [kit onRemoveUserAttribute:filteredUser];
+                                                                                    }
+                                                                                }];
+                                       });
                                    }
                            }];
     });
@@ -326,23 +345,29 @@
 #pragma mark - User Segments
 - (void)userSegments:(NSTimeInterval)timeout endpointId:(NSString *)endpointId completionHandler:(MPUserSegmentsHandler)completionHandler {
     dispatch_async([MParticle messageQueue], ^{
-        MPExecStatus execStatus = [self.backendController fetchSegments:timeout
-                                                             endpointId:endpointId
-                                                      completionHandler:^(NSArray *segments, NSTimeInterval elapsedTime, NSError *error) {
-                                                          if (!segments) {
-                                                              completionHandler(nil, error);
-                                                              return;
-                                                          }
-                                                          
-                                                          MPUserSegments *userSegments = [[MPUserSegments alloc] initWithSegments:segments];
-                                                          completionHandler(userSegments, error);
-                                                      }];
-        
-        if (execStatus == MPExecStatusSuccess) {
-            MPILogDebug(@"Fetching user segments");
-        } else {
-            MPILogError(@"Could not fetch user segments: %@", [self.backendController execStatusDescription:execStatus]);
-        }
+        dispatch_async([MParticle networkQueue], ^{
+            MPExecStatus execStatus = [self.backendController fetchSegments:timeout
+                                                                 endpointId:endpointId
+                                                          completionHandler:^(NSArray *segments, NSTimeInterval elapsedTime, NSError *error) {
+                                                              if (!segments) {
+                                                                  dispatch_async(dispatch_get_main_queue(), ^{
+                                                                      completionHandler(nil, error);
+                                                                  });
+                                                                  return;
+                                                              }
+                                                              
+                                                              MPUserSegments *userSegments = [[MPUserSegments alloc] initWithSegments:segments];
+                                                              dispatch_async(dispatch_get_main_queue(), ^{
+                                                                  completionHandler(userSegments, error);
+                                                              });
+                                                          }];
+            
+            if (execStatus == MPExecStatusSuccess) {
+                MPILogDebug(@"Fetching user segments");
+            } else {
+                MPILogError(@"Could not fetch user segments: %@", [self.backendController execStatusDescription:execStatus]);
+            }
+        });
     });
 }
 
@@ -354,11 +379,12 @@
     
     NSArray<NSDictionary *> *kitConfig = [[MPKitContainer sharedInstance].originalConfig copy];
     if (kitConfig) {
-        [[MPKitContainer sharedInstance] configureKits:kitConfig];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[MPKitContainer sharedInstance] configureKits:kitConfig];
+        });
     }
     
-    
-    dispatch_async([MParticle messageQueue], ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         [[MPKitContainer sharedInstance] forwardSDKCall:@selector(setConsentState:) consentState:state kitHandler:^(id<MPKitProtocol>  _Nonnull kit, MPConsentState * _Nullable filteredConsentState, MPKitConfiguration * _Nonnull kitConfiguration) {
             MPKitExecStatus *status = [kit setConsentState:filteredConsentState];
             if (!status.success) {

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.h
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.h
@@ -24,7 +24,7 @@
 - (nullable NSArray<id<MPExtensionKitProtocol>> *)activeKitsRegistry;
 - (void)configureKits:(nullable NSArray<NSDictionary *> *)kitsConfiguration;
 - (nullable NSArray<NSNumber *> *)supportedKits;
-
+- (void)initializeKits;
 - (void)forwardCommerceEventCall:(nonnull MPCommerceEvent *)commerceEvent kitHandler:(void (^ _Nonnull)(id<MPKitProtocol> _Nonnull kit, MPKitFilter * _Nonnull kitFilter, MPKitExecStatus * _Nonnull * _Nonnull execStatus))kitHandler;
 - (void)forwardSDKCall:(nonnull SEL)selector event:(nullable MPEvent *)event messageType:(MPMessageType)messageType userInfo:(nullable NSDictionary *)userInfo kitHandler:(void (^ _Nonnull)(id<MPKitProtocol> _Nonnull kit, MPEvent * _Nullable forwardEvent, MPKitExecStatus * _Nonnull * _Nonnull execStatus))kitHandler;
 - (void)forwardSDKCall:(nonnull SEL)selector userAttributeKey:(nonnull NSString *)key value:(nullable id)value kitHandler:(void (^ _Nonnull)(id<MPKitProtocol> _Nonnull kit, MPKitConfiguration * _Nonnull kitConfiguration))kitHandler;

--- a/mParticle-Apple-SDK/Kits/MPKitContainer.mm
+++ b/mParticle-Apple-SDK/Kits/MPKitContainer.mm
@@ -35,6 +35,7 @@
 #import "mParticle.h"
 #import "MPConsentKitFilter.h"
 #import "MPIConstants.h"
+#import "MPILogger.h"
 
 #define DEFAULT_ALLOCATION_FOR_KITS 2
 
@@ -95,10 +96,6 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
             }
         } copy];
         
-        if (![MPStateMachine sharedInstance].optOut) {
-            [self initializeKits];
-        }
-        
         NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
         [notificationCenter addObserver:self
                                selector:@selector(handleApplicationDidBecomeActive:)
@@ -122,40 +119,44 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
 
 #pragma mark Notification handlers
 - (void)handleApplicationDidBecomeActive:(NSNotification *)notification {
-    NSArray<id<MPExtensionKitProtocol>> *activeKitsRegistry = [self activeKitsRegistry];
-    SEL didBecomeActiveSelector = @selector(didBecomeActive);
-    
-    for (id<MPExtensionKitProtocol>kitRegister in activeKitsRegistry) {
-        if ([kitRegister.wrapperInstance respondsToSelector:didBecomeActiveSelector]) {
-            [kitRegister.wrapperInstance didBecomeActive];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSArray<id<MPExtensionKitProtocol>> *activeKitsRegistry = [self activeKitsRegistry];
+        SEL didBecomeActiveSelector = @selector(didBecomeActive);
+        
+        for (id<MPExtensionKitProtocol>kitRegister in activeKitsRegistry) {
+            if ([kitRegister.wrapperInstance respondsToSelector:didBecomeActiveSelector]) {
+                [kitRegister.wrapperInstance didBecomeActive];
+            }
         }
-    }
+    });
 }
 
 - (void)handleApplicationDidFinishLaunching:(NSNotification *)notification {
-    MPStateMachine *stateMachine = [MPStateMachine sharedInstance];
-    stateMachine.launchOptions = [notification userInfo];
-    SEL launchOptionsSelector = @selector(setLaunchOptions:);
-    SEL startSelector = @selector(start);
-    
-    for (id<MPExtensionKitProtocol>kitRegister in kitsRegistry) {
-        id<MPKitProtocol> kitInstance = kitRegister.wrapperInstance;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        MPStateMachine *stateMachine = [MPStateMachine sharedInstance];
+        stateMachine.launchOptions = [notification userInfo];
+        SEL launchOptionsSelector = @selector(setLaunchOptions:);
+        SEL startSelector = @selector(start);
         
-        if (kitInstance && ![kitInstance started]) {
-            if ([kitInstance respondsToSelector:launchOptionsSelector]) {
-                [kitInstance setLaunchOptions:stateMachine.launchOptions];
-            }
+        for (id<MPExtensionKitProtocol>kitRegister in kitsRegistry) {
+            id<MPKitProtocol> kitInstance = kitRegister.wrapperInstance;
             
-            if ([kitInstance respondsToSelector:startSelector]) {
-                @try {
-                    [kitInstance start];
+            if (kitInstance && ![kitInstance started]) {
+                if ([kitInstance respondsToSelector:launchOptionsSelector]) {
+                    [kitInstance setLaunchOptions:stateMachine.launchOptions];
                 }
-                @catch (NSException *exception) {
-                    MPILogError(@"Exception thrown while starting kit (%@): %@", kitInstance, exception);
+                
+                if ([kitInstance respondsToSelector:startSelector]) {
+                    @try {
+                        [kitInstance start];
+                    }
+                    @catch (NSException *exception) {
+                        MPILogError(@"Exception thrown while starting kit (%@): %@", kitInstance, exception);
+                    }
                 }
             }
         }
-    }
+    });
 }
 
 #pragma mark Private accessors
@@ -193,9 +194,11 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
 }
 
 - (void)flushSerializedKits {
-    for (id<MPExtensionKitProtocol>kitRegister in kitsRegistry) {
-        [self freeKit:kitRegister.code];
-    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        for (id<MPExtensionKitProtocol>kitRegister in kitsRegistry) {
+            [self freeKit:kitRegister.code];
+        }
+    });
 }
 
 - (void)freeKit:(NSNumber *)kitCode {
@@ -219,17 +222,18 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
             [fileManager removeItemAtPath:kitPath error:nil];
         }
 
-        dispatch_async(dispatch_get_main_queue(), ^{
-            NSDictionary *userInfo = @{mParticleKitInstanceKey:kitCode};
-            
-            [[NSNotificationCenter defaultCenter] postNotificationName:mParticleKitDidBecomeInactiveNotification
-                                                                object:nil
-                                                              userInfo:userInfo];
-        });
+        NSDictionary *userInfo = @{mParticleKitInstanceKey:kitCode};
+        
+        [[NSNotificationCenter defaultCenter] postNotificationName:mParticleKitDidBecomeInactiveNotification
+                                                            object:nil
+                                                          userInfo:userInfo];
     }
 }
 
 - (void)initializeKits {
+    if (self.kitsInitialized) {
+        return;
+    }
     MPIUserDefaults *userDefaults = [MPIUserDefaults standardUserDefaults];
 
     NSArray *directoryContents = [userDefaults getKitConfigurations];
@@ -241,24 +245,21 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
         
         self.kitsInitialized = YES;
     }
-    
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if ([MPStateMachine sharedInstance].logLevel >= MPILogLevelDebug) {
-            NSArray<NSNumber *> *supportedKits = [self supportedKits];
-            
-            if (supportedKits.count > 0) {
-                NSMutableString *listOfKits = [[NSMutableString alloc] initWithString:@"Included kits: {"];
-                for (NSNumber *supportedKit in supportedKits) {
-                    [listOfKits appendFormat:@"%@, ", [self nameForKitCode:supportedKit]];
-                }
-                
-                [listOfKits deleteCharactersInRange:NSMakeRange(listOfKits.length - 2, 2)];
-                [listOfKits appendString:@"}"];
-                
-                MPILogDebug(@"%@", listOfKits);
+    if ([MPStateMachine sharedInstance].logLevel >= MPILogLevelDebug) {
+        NSArray<NSNumber *> *supportedKits = [self supportedKits];
+        
+        if (supportedKits.count > 0) {
+            NSMutableString *listOfKits = [[NSMutableString alloc] initWithString:@"Included kits: {"];
+            for (NSNumber *supportedKit in supportedKits) {
+                [listOfKits appendFormat:@"%@, ", [self nameForKitCode:supportedKit]];
             }
+            
+            [listOfKits deleteCharactersInRange:NSMakeRange(listOfKits.length - 2, 2)];
+            [listOfKits appendString:@"}"];
+            
+            MPILogDebug(@"%@", listOfKits);
         }
-    });
+    }
 }
 
 - (NSDictionary *)methodMessageTypeMapping {
@@ -300,21 +301,21 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
     for (MPForwardQueueItem *forwardQueueItem in forwardQueueCopy) {
         switch (forwardQueueItem.queueItemType) {
             case MPQueueItemTypeEvent: {
-                dispatch_async([MParticle messageQueue], ^{
+                dispatch_async(dispatch_get_main_queue(), ^{
                     [self forwardSDKCall:forwardQueueItem.selector event:forwardQueueItem.event messageType:forwardQueueItem.messageType userInfo:nil kitHandler:forwardQueueItem.eventCompletionHandler];
                 });
                 break;
             }
                 
             case MPQueueItemTypeEcommerce: {
-                dispatch_async([MParticle messageQueue], ^{
+                dispatch_async(dispatch_get_main_queue(), ^{
                     [self forwardCommerceEventCall:forwardQueueItem.commerceEvent kitHandler:forwardQueueItem.commerceEventCompletionHandler];
                 });
                 break;
             }
                 
             case MPQueueItemTypeGeneralPurpose: {
-                dispatch_async([MParticle messageQueue], ^{
+                dispatch_async(dispatch_get_main_queue(), ^{
                     [self forwardSDKCall:forwardQueueItem.selector parameters:forwardQueueItem.queueParameters messageType:forwardQueueItem.messageType kitHandler:forwardQueueItem.generalPurposeCompletionHandler];
                 });
                 break;
@@ -2075,44 +2076,45 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
         
         return;
     }
-    
-    NSArray<id<MPExtensionKitProtocol>> *activeKitsRegistry = [self activeKitsRegistry];
-    
-    for (id<MPExtensionKitProtocol>kitRegister in activeKitsRegistry) {
-        __block NSNumber *lastKit = nil;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSArray<id<MPExtensionKitProtocol>> *activeKitsRegistry = [self activeKitsRegistry];
         
-        [self filter:kitRegister forCommerceEvent:commerceEvent completionHandler:^(MPKitFilter *kitFilter, BOOL finished) {
-            if (kitFilter.shouldFilter && !kitFilter.filteredAttributes) {
-                return;
-            }
+        for (id<MPExtensionKitProtocol>kitRegister in activeKitsRegistry) {
+            __block NSNumber *lastKit = nil;
             
-            if (kitFilter.forwardCommerceEvent || kitFilter.forwardEvent) {
-                __block MPKitExecStatus *execStatus = nil;
-                
-                dispatch_sync(dispatch_get_main_queue(), ^{
-                    @try {
-                        kitHandler(kitRegister.wrapperInstance, kitFilter, &execStatus);
-                    } @catch (NSException *e) {
-                        MPILogError(@"Kit handler threw an exception: %@", e);
-                    }
-                });
-                
-                NSNumber *currentKit = kitRegister.code;
-                if (execStatus.success && ![lastKit isEqualToNumber:currentKit]) {
-                    lastKit = currentKit;
-                    
-                    MPForwardRecord *forwardRecord = [[MPForwardRecord alloc] initWithMessageType:MPMessageTypeCommerceEvent
-                                                                                       execStatus:execStatus
-                                                                                        kitFilter:kitFilter
-                                                                                    originalEvent:commerceEvent];
-                    
-                    [[MPPersistenceController sharedInstance] saveForwardRecord:forwardRecord];
-                    
-                    MPILogDebug(@"Forwarded logCommerceEvent call to kit: %@", kitRegister.name);
+            [self filter:kitRegister forCommerceEvent:commerceEvent completionHandler:^(MPKitFilter *kitFilter, BOOL finished) {
+                if (kitFilter.shouldFilter && !kitFilter.filteredAttributes) {
+                    return;
                 }
-            }
-        }];
-    }
+                
+                if (kitFilter.forwardCommerceEvent || kitFilter.forwardEvent) {
+                    __block MPKitExecStatus *execStatus = nil;
+                    
+                    
+                        @try {
+                            kitHandler(kitRegister.wrapperInstance, kitFilter, &execStatus);
+                        } @catch (NSException *e) {
+                            MPILogError(@"Kit handler threw an exception: %@", e);
+                        }
+                    
+                    
+                    NSNumber *currentKit = kitRegister.code;
+                    if (execStatus.success && ![lastKit isEqualToNumber:currentKit]) {
+                        lastKit = currentKit;
+                        
+                        MPForwardRecord *forwardRecord = [[MPForwardRecord alloc] initWithMessageType:MPMessageTypeCommerceEvent
+                                                                                           execStatus:execStatus
+                                                                                            kitFilter:kitFilter
+                                                                                        originalEvent:commerceEvent];
+                        dispatch_async([MParticle messageQueue], ^{
+                            [[MPPersistenceController sharedInstance] saveForwardRecord:forwardRecord];
+                        });
+                        MPILogDebug(@"Forwarded logCommerceEvent call to kit: %@", kitRegister.name);
+                    }
+                }
+            }];
+        }
+    });
 }
 
 - (void)forwardSDKCall:(SEL)selector event:(MPEvent *)event messageType:(MPMessageType)messageType userInfo:(NSDictionary *)userInfo kitHandler:(void (^)(id<MPKitProtocol> kit, MPEvent *forwardEvent, MPKitExecStatus **execStatus))kitHandler {
@@ -2124,6 +2126,7 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
         MPForwardQueueItem *forwardQueueItem = [[MPForwardQueueItem alloc] initWithSelector:selector event:event messageType:messageType completionHandler:kitHandler];
         
         if (forwardQueueItem) {
+            MPILogVerbose(@"Queueing event message for kits: %@", event);
             [self.forwardQueue addObject:forwardQueueItem];
         }
         
@@ -2142,17 +2145,16 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
             
             if (kitFilter.forwardEvent) {
                 __block MPKitExecStatus *execStatus = nil;
-                
-                dispatch_sync(dispatch_get_main_queue(), ^{
-                    @try {
-                        kitHandler(kitRegister.wrapperInstance, kitFilter.forwardEvent, &execStatus);
-                    } @catch (NSException *e) {
-                        MPILogError(@"Kit handler threw an exception: %@", e);
-                    }
-                });
+
+                @try {
+                    MPILogDebug(@"Forwarding %@ call to kit: %@", NSStringFromSelector(selector), kitRegister.name);
+                    kitHandler(kitRegister.wrapperInstance, kitFilter.forwardEvent, &execStatus);
+                } @catch (NSException *e) {
+                    MPILogError(@"Kit handler threw an exception: %@", e);
+                }
                 
                 NSNumber *currentKit = kitRegister.code;
-                if (execStatus.success && ![lastKit isEqualToNumber:currentKit] && kitFilter.forwardEvent && messageType != MPMessageTypeUnknown) {
+                if (execStatus.success && ![lastKit isEqualToNumber:currentKit] && messageType != MPMessageTypeUnknown) {
                     lastKit = currentKit;
                     
                     MPForwardRecord *forwardRecord = nil;
@@ -2167,10 +2169,9 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
                                                                            kitFilter:kitFilter
                                                                        originalEvent:event];
                     }
-                    
-                    [[MPPersistenceController sharedInstance] saveForwardRecord:forwardRecord];
-                    
-                    MPILogDebug(@"Forwarded %@ call to kit: %@", NSStringFromSelector(selector), kitRegister.name);
+                    dispatch_async([MParticle messageQueue], ^{
+                        [[MPPersistenceController sharedInstance] saveForwardRecord:forwardRecord];
+                    });
                 }
             }
         };
@@ -2208,13 +2209,11 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
             if (!kitFilter.shouldFilter) {
                 MPKitConfiguration *kitConfiguration = self.kitConfigurations[kitRegister.code];
                 
-                dispatch_sync(dispatch_get_main_queue(), ^{
-                    @try {
-                        kitHandler(kitRegister.wrapperInstance, kitConfiguration);
-                    } @catch (NSException *e) {
-                        MPILogError(@"Kit handler threw an exception: %@", e);
-                    }
-                });
+                @try {
+                    kitHandler(kitRegister.wrapperInstance, kitConfiguration);
+                } @catch (NSException *e) {
+                    MPILogError(@"Kit handler threw an exception: %@", e);
+                }
                 
                 MPILogDebug(@"Forwarded user attribute key: %@ value: %@ to kit: %@", key, value, kitRegister.name);
             }
@@ -2230,13 +2229,12 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
             MPKitFilter *kitFilter = [self filter:kitRegister forUserAttributes:userAttributes];
             
             MPKitConfiguration *kitConfiguration = self.kitConfigurations[kitRegister.code];
-            dispatch_sync(dispatch_get_main_queue(), ^{
-                @try {
-                    kitHandler(kitRegister.wrapperInstance, kitFilter.filteredAttributes, kitConfiguration);
-                } @catch (NSException *e) {
-                    MPILogError(@"Kit handler threw an exception: %@", e);
-                }
-            });
+            
+            @try {
+                kitHandler(kitRegister.wrapperInstance, kitFilter.filteredAttributes, kitConfiguration);
+            } @catch (NSException *e) {
+                MPILogError(@"Kit handler threw an exception: %@", e);
+            }
             
             MPILogDebug(@"Forwarded user attributes to kit: %@", kitRegister.name);
         }
@@ -2252,13 +2250,12 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
             
             if (!kitFilter.shouldFilter) {
                 MPKitConfiguration *kitConfiguration = self.kitConfigurations[kitRegister.code];
-                dispatch_sync(dispatch_get_main_queue(), ^{
-                    @try {
-                        kitHandler(kitRegister.wrapperInstance, kitConfiguration);
-                    } @catch (NSException *e) {
-                        MPILogError(@"Kit handler threw an exception: %@", e);
-                    }
-                });
+                
+                @try {
+                    kitHandler(kitRegister.wrapperInstance, kitConfiguration);
+                } @catch (NSException *e) {
+                    MPILogError(@"Kit handler threw an exception: %@", e);
+                }
                 
                 MPILogDebug(@"Forwarded setting user identity: %@ to kit: %@", identityString, kitRegister.name);
             }
@@ -2274,13 +2271,12 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
             MPKitFilter *kitFilter = [self filter:kitRegister forConsentState:state];
             if (!kitFilter.shouldFilter) {
                 MPKitConfiguration *kitConfiguration = self.kitConfigurations[kitRegister.code];
-                dispatch_sync(dispatch_get_main_queue(), ^{
-                    @try {
-                        kitHandler(kitRegister.wrapperInstance, kitFilter.forwardConsentState, kitConfiguration);
-                    } @catch (NSException *e) {
-                        MPILogError(@"Kit handler threw an exception: %@", e);
-                    }
-                });
+                
+                @try {
+                    kitHandler(kitRegister.wrapperInstance, kitFilter.forwardConsentState, kitConfiguration);
+                } @catch (NSException *e) {
+                    MPILogError(@"Kit handler threw an exception: %@", e);
+                }
                 
                 MPILogDebug(@"Forwarded user attributes to kit: %@", kitRegister.name);
             }
@@ -2297,16 +2293,13 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
             
             if (!kitFilter.shouldFilter) {
                 __block MPKitExecStatus *execStatus = nil;
-                
-                dispatch_sync(dispatch_get_main_queue(), ^{
-                    @try {
-                        kitHandler(kitRegister.wrapperInstance, &execStatus);
-                    } @catch (NSException *e) {
-                        MPILogError(@"Kit handler threw an exception: %@", e);
-                    }
-                });
-                
-                MPILogDebug(@"Forwarded %@ call to kit: %@", NSStringFromSelector(selector), kitRegister.name);
+            
+                @try {
+                    MPILogDebug(@"Forwarding %@ call to kit: %@", NSStringFromSelector(selector), kitRegister.name);
+                    kitHandler(kitRegister.wrapperInstance, &execStatus);
+                } @catch (NSException *e) {
+                    MPILogError(@"Kit handler threw an exception: %@", e);
+                }
             }
         }
     }
@@ -2319,15 +2312,12 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
         if ([kitRegister.wrapperInstance respondsToSelector:selector]) {
             __block MPKitExecStatus *execStatus = nil;
             
-            dispatch_sync(dispatch_get_main_queue(), ^{
-                @try {
-                    kitHandler(kitRegister.wrapperInstance, &execStatus);
-                } @catch (NSException *e) {
-                    MPILogError(@"Kit handler threw an exception: %@", e);
-                }
-            });
-            
-            MPILogDebug(@"Forwarded %@ call to kit: %@", NSStringFromSelector(selector), kitRegister.name);
+            @try {
+                MPILogDebug(@"Forwarding %@ call to kit: %@", NSStringFromSelector(selector), kitRegister.name);
+                kitHandler(kitRegister.wrapperInstance, &execStatus);
+            } @catch (NSException *e) {
+                MPILogError(@"Kit handler threw an exception: %@", e);
+            }
         }
     }
 }
@@ -2353,13 +2343,12 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
                 __block MPKitExecStatus *execStatus = nil;
                 NSNumber *currentKit = kitRegister.code;
                 
-                dispatch_sync(dispatch_get_main_queue(), ^{
-                    @try {
-                        kitHandler(kitRegister.wrapperInstance, parameters, &execStatus);
-                    } @catch (NSException *e) {
-                        MPILogError(@"Kit handler threw an exception: %@", e);
-                    }
-                });
+                @try {
+                    MPILogDebug(@"Forwarding %@ call to kit: %@", NSStringFromSelector(selector), kitRegister.name);
+                    kitHandler(kitRegister.wrapperInstance, parameters, &execStatus);
+                } @catch (NSException *e) {
+                    MPILogError(@"Kit handler threw an exception: %@", e);
+                }
                 
                 if (execStatus.success && ![lastKit isEqualToNumber:currentKit]) {
                     lastKit = currentKit;
@@ -2382,11 +2371,11 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
                         }
                         
                         if (forwardRecord) {
-                            [[MPPersistenceController sharedInstance] saveForwardRecord:forwardRecord];
+                            dispatch_async([MParticle messageQueue], ^{
+                                [[MPPersistenceController sharedInstance] saveForwardRecord:forwardRecord];
+                            });
                         }
                     }
-                    
-                    MPILogDebug(@"Forwarded %@ call to kit: %@", NSStringFromSelector(selector), kitRegister.name);
                 }
             } @catch (NSException *exception) {
                 MPILogError(@"An exception happened forwarding %@ to kit: %@\n  reason: %@", NSStringFromSelector(selector), kitRegister.name, [exception reason]);
@@ -2402,9 +2391,8 @@ static NSMutableSet <id<MPExtensionKitProtocol>> *kitsRegistry;
         if ([kitRegister.wrapperInstance respondsToSelector:selector]) {
             MPKitConfiguration *kitConfiguration = self.kitConfigurations[kitRegister.code];
             
+            MPILogDebug(@"Forwarding %@ call to kit: %@", NSStringFromSelector(selector), kitRegister.name);
             kitHandler(kitRegister.wrapperInstance, kitConfiguration);
-            
-            MPILogDebug(@"Forwarded %@ call to kit: %@", NSStringFromSelector(selector), kitRegister.name);
         }
     }
 }

--- a/mParticle-Apple-SDK/MPBackendController.h
+++ b/mParticle-Apple-SDK/MPBackendController.h
@@ -46,7 +46,7 @@ typedef NS_ENUM(NSUInteger, MPExecStatus) {
 #if TARGET_OS_IOS == 1
 <MPNotificationControllerDelegate>
 
-@property (nonatomic, strong, nonnull) MPNotificationController *notificationController NS_EXTENSION_UNAVAILABLE_IOS("");
+@property (nonatomic, strong, nonnull) MPNotificationController *notificationController;
 #endif
 
 @property (nonatomic, weak, nullable) id<MPBackendControllerDelegate> delegate;
@@ -88,7 +88,7 @@ typedef NS_ENUM(NSUInteger, MPExecStatus) {
 - (MPExecStatus)beginLocationTrackingWithAccuracy:(CLLocationAccuracy)accuracy distanceFilter:(CLLocationDistance)distance authorizationRequest:(MPLocationAuthorizationRequest)authorizationRequest;
 - (MPExecStatus)endLocationTracking;
 - (void)handleDeviceTokenNotification:(nonnull NSNotification *)notification;
-- (void)receivedUserNotification:(nonnull MParticleUserNotification *)userNotification NS_EXTENSION_UNAVAILABLE_IOS("");
+- (void)receivedUserNotification:(nonnull MParticleUserNotification *)userNotification;
 #endif
 
 @end

--- a/mParticle-Apple-SDK/MPExceptionHandler.m
+++ b/mParticle-Apple-SDK/MPExceptionHandler.m
@@ -18,6 +18,7 @@
 #import "MPPersistenceController.h"
 #import "MPILogger.h"
 #import "MPMessageBuilder.h"
+#import "MPApplication.h"
 
 #if defined(MP_CRASH_REPORTER) && TARGET_OS_IOS == 1
     #import <mParticle-CrashReporter/CrashReporter.h>
@@ -166,12 +167,12 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
 }
 
 - (NSString *)topmostContext {
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-    UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
-    id topmostContext = [self topViewControllerForController:rootViewController];
-    NSString *topmostContextName = [[topmostContext class] description];
-    return topmostContextName;
-#endif
+    if (![MPStateMachine isAppExtension]) {
+        UIViewController *rootViewController = [MPApplication sharedUIApplication].keyWindow.rootViewController;
+        id topmostContext = [self topViewControllerForController:rootViewController];
+        NSString *topmostContextName = [[topmostContext class] description];
+        return topmostContextName;
+    }
     return @"extension_context";
 }
 
@@ -220,30 +221,46 @@ static void processBinaryImage(const char *name, const void *header, struct uuid
             id value = nil;
             switch (idx) {
                 case CrashArchiveTypeCurrentState:
-                    value = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+                    @try {
+                        value = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+                    } @catch (NSException* ex) {
+                        MPILogger(MPILogLevelError, @"Failed To retrieve crash current state type: %@", ex);
+                    }
                     break;
 
                 case CrashArchiveTypeException: {
-                    NSException *exception = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
-                    
-                    crashInfo[kMPErrorMessage] = [exception reason];
-                    crashInfo[kMPCrashingClass] = [exception name];
+                    @try {
+                        NSException *exception = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+                        
+                        crashInfo[kMPErrorMessage] = [exception reason];
+                        crashInfo[kMPCrashingClass] = [exception name];
+                    } @catch (NSException* ex) {
+                        MPILogger(MPILogLevelError, @"Failed To retrieve crash exception type: %@", ex);
+                    }
                 }
                     break;
                     
                 case CrashArchiveTypeAppImageInfo:
-                    unarchivedDictionary = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
-                    key = kMPAppImageBaseAddressKey;
-                    value = unarchivedDictionary[key];
-                    crashInfo[key] = value;
-                    
-                    key = kMPAppImageSizeKey;
-                    value = unarchivedDictionary[key];
+                    @try {
+                        unarchivedDictionary = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+                        key = kMPAppImageBaseAddressKey;
+                        value = unarchivedDictionary[key];
+                        crashInfo[key] = value;
+                        
+                        key = kMPAppImageSizeKey;
+                        value = unarchivedDictionary[key];
+                    } @catch (NSException* ex) {
+                        MPILogger(MPILogLevelError, @"Failed To retrieve crash app image info type: %@", ex);
+                    }
                     break;
                     
                 default:
-                    unarchivedDictionary = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
-                    value = unarchivedDictionary[key];
+                    @try {
+                        unarchivedDictionary = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+                        value = unarchivedDictionary[key];
+                    } @catch (NSException* ex) {
+                        MPILogger(MPILogLevelError, @"Failed To retrieve crash default type: %@", ex);
+                    }
                     break;
             }
             

--- a/mParticle-Apple-SDK/MPIConstants.h
+++ b/mParticle-Apple-SDK/MPIConstants.h
@@ -11,6 +11,15 @@
 #define STATE_MACHINE_DIRECTORY_PATH [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)[0] stringByAppendingPathComponent:@"StateMachine"];
 
 #define MPIsNull(object) ((object) == nil || (NSNull *)(object) == [NSNull null])
+#define MPIsDictionary(object) (!MPIsNull(object) && [object isKindOfClass:[NSDictionary class]])
+#define MPIsArray(object) (!MPIsNull(object) && [object isKindOfClass:[NSArray class]])
+#define MPIsString(object) (!MPIsNull(object) && [object isKindOfClass:[NSString class]])
+#define MPIsNumber(object) (!MPIsNull(object) && [object isKindOfClass:[NSNumber class]])
+
+#define MPIsNonEmptyDictionary(object) (MPIsDictionary(object) && ((NSDictionary *)object).count > 0)
+#define MPIsNonEmptyArray(object) (MPIsArray(object) && ((NSArray *)object).count > 0)
+#define MPIsNonEmptyString(object) (MPIsString(object) && ((NSString *)object).length > 0)
+#define MPIsNonZeroNumber(object) (MPIsNumber(object) && ![(NSNumber *)object) isEqual:@0])
 
 typedef NS_ENUM(NSInteger, MPUploadStatus) {
     MPUploadStatusUnknown = -1,

--- a/mParticle-Apple-SDK/MPIConstants.m
+++ b/mParticle-Apple-SDK/MPIConstants.m
@@ -1,7 +1,7 @@
 #import "MPIConstants.h"
 
 // mParticle SDK Version
-NSString *const kMParticleSDKVersion = @"7.3.9";
+NSString *const kMParticleSDKVersion = @"7.4.1";
 
 // Message Type (dt)
 NSString *const kMPMessageTypeKey = @"dt";

--- a/mParticle-Apple-SDK/Network/MPNetworkCommunication.mm
+++ b/mParticle-Apple-SDK/Network/MPNetworkCommunication.mm
@@ -297,15 +297,16 @@ NSString *const kMPURLHostIdentity = @"identity.mparticle.com";
     MPILogVerbose(@"Starting config request");
     NSTimeInterval start = [[NSDate date] timeIntervalSince1970];
     
-#if !defined(MPARTICLE_APP_EXTENSIONS)
     __block UIBackgroundTaskIdentifier backgroundTaskIdentifier = UIBackgroundTaskInvalid;
-    backgroundTaskIdentifier = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
-        if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
-            [[UIApplication sharedApplication] endBackgroundTask:backgroundTaskIdentifier];
-            backgroundTaskIdentifier = UIBackgroundTaskInvalid;
-        }
-    }];
-#endif
+
+    if (![MPStateMachine isAppExtension]) {
+        backgroundTaskIdentifier = [[MPApplication sharedUIApplication] beginBackgroundTaskWithExpirationHandler:^{
+            if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+                [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
+                backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+            }
+        }];
+    }
     
     MPConnector *connector = [[MPConnector alloc] init];
     NSString *const connectionId = [[NSUUID UUID] UUIDString];
@@ -321,12 +322,12 @@ NSString *const kMPURLHostIdentity = @"identity.mparticle.com";
         return;
     }
     
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-    if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
-        [[UIApplication sharedApplication] endBackgroundTask:backgroundTaskIdentifier];
-        backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    if (![MPStateMachine isAppExtension]) {
+        if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+            [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
+            backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+        }
     }
-#endif
     
     NSInteger responseCode = [httpResponse statusCode];
     MPILogVerbose(@"Config Response Code: %ld, Execution Time: %.2fms", (long)responseCode, ([[NSDate date] timeIntervalSince1970] - start) * 1000.0);
@@ -400,15 +401,16 @@ NSString *const kMPURLHostIdentity = @"identity.mparticle.com";
     
     retrievingSegments = YES;
     
-#if !defined(MPARTICLE_APP_EXTENSIONS)
     __block UIBackgroundTaskIdentifier backgroundTaskIdentifier = UIBackgroundTaskInvalid;
-    backgroundTaskIdentifier = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
-        if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
-            [[UIApplication sharedApplication] endBackgroundTask:backgroundTaskIdentifier];
-            backgroundTaskIdentifier = UIBackgroundTaskInvalid;
-        }
-    }];
-#endif
+    
+    if (![MPStateMachine isAppExtension]) {
+        backgroundTaskIdentifier = [[MPApplication sharedUIApplication] beginBackgroundTaskWithExpirationHandler:^{
+            if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+                [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
+                backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+            }
+        }];
+    }
     
     MPConnector *connector = [[MPConnector alloc] init];
     
@@ -425,12 +427,12 @@ NSString *const kMPURLHostIdentity = @"identity.mparticle.com";
         return;
     }
     
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-    if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
-        [[UIApplication sharedApplication] endBackgroundTask:backgroundTaskIdentifier];
-        backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    if (![MPStateMachine isAppExtension]) {
+        if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+            [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
+            backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+        }
     }
-#endif
     
     if (!data) {
         completionHandler(NO, nil, elapsedTime, nil);
@@ -523,16 +525,16 @@ NSString *const kMPURLHostIdentity = @"identity.mparticle.com";
 - (void)upload:(NSArray<MPUpload *> *)uploads index:(NSUInteger)index completionHandler:(MPUploadsCompletionHandler)completionHandler {
     __weak MPNetworkCommunication *weakSelf = self;
     
-#if !defined(MPARTICLE_APP_EXTENSIONS)
     __block UIBackgroundTaskIdentifier backgroundTaskIdentifier = UIBackgroundTaskInvalid;
     
-    backgroundTaskIdentifier = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
-        if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
-            [[UIApplication sharedApplication] endBackgroundTask:backgroundTaskIdentifier];
-            backgroundTaskIdentifier = UIBackgroundTaskInvalid;
-        }
-    }];
-#endif
+    if (![MPStateMachine isAppExtension]) {
+        backgroundTaskIdentifier = [[MPApplication sharedUIApplication] beginBackgroundTaskWithExpirationHandler:^{
+            if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+                [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
+                backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+            }
+        }];
+    }
     
     MPUpload *upload = uploads[index];
     NSString *uploadString = [upload serializedString];
@@ -567,12 +569,12 @@ NSString *const kMPURLHostIdentity = @"identity.mparticle.com";
         return;
     }
     
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-    if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
-        [[UIApplication sharedApplication] endBackgroundTask:backgroundTaskIdentifier];
-        backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    if (![MPStateMachine isAppExtension]) {
+        if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+            [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
+            backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+        }
     }
-#endif
     
     NSDictionary *responseDictionary = nil;
     MPNetworkResponseAction responseAction = MPNetworkResponseActionNone;
@@ -646,21 +648,21 @@ NSString *const kMPURLHostIdentity = @"identity.mparticle.com";
     }
     __weak MPNetworkCommunication *weakSelf = self;
     
-#if !defined(MPARTICLE_APP_EXTENSIONS)
     __block UIBackgroundTaskIdentifier backgroundTaskIdentifier = UIBackgroundTaskInvalid;
     
-    backgroundTaskIdentifier = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
-        if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
-            __strong MPNetworkCommunication *strongSelf = weakSelf;
-            if (strongSelf) {
-                strongSelf->identifying = NO;
+    if (![MPStateMachine isAppExtension]) {
+        backgroundTaskIdentifier = [[MPApplication sharedUIApplication] beginBackgroundTaskWithExpirationHandler:^{
+            if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+                __strong MPNetworkCommunication *strongSelf = weakSelf;
+                if (strongSelf) {
+                    strongSelf->identifying = NO;
+                }
+                
+                [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
+                backgroundTaskIdentifier = UIBackgroundTaskInvalid;
             }
-            
-            [[UIApplication sharedApplication] endBackgroundTask:backgroundTaskIdentifier];
-            backgroundTaskIdentifier = UIBackgroundTaskInvalid;
-        }
-    }];
-#endif
+        }];
+    }
     
     MPConnector *connector = [[MPConnector alloc] init];
     NSString *const connectionId = [[NSUUID UUID] UUIDString];
@@ -693,12 +695,12 @@ NSString *const kMPURLHostIdentity = @"identity.mparticle.com";
         return;
     }
     
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-    if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
-        [[UIApplication sharedApplication] endBackgroundTask:backgroundTaskIdentifier];
-        backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    if (![MPStateMachine isAppExtension]) {
+        if (backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
+            [[MPApplication sharedUIApplication] endBackgroundTask:backgroundTaskIdentifier];
+            backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+        }
     }
-#endif
     
     NSDictionary *responseDictionary = nil;
     NSString *responseString = nil;

--- a/mParticle-Apple-SDK/Network/MPURLRequestBuilder.m
+++ b/mParticle-Apple-SDK/Network/MPURLRequestBuilder.m
@@ -7,6 +7,7 @@
 #import "MPKitContainer.h"
 #import "MPExtensionProtocol.h"
 #import "MPILogger.h"
+#import "MPApplication.h"
 
 static NSDateFormatter *RFC1123DateFormatter;
 static NSTimeInterval requestTimeout = 30.0;
@@ -86,12 +87,13 @@ static NSString *mpUserAgent = nil;
             }
             
             dispatch_block_t getUserAgent = ^{
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-                if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {
-                    mpUserAgent = defaultUserAgent;
-                    return;
+                if (![MPStateMachine isAppExtension]) {
+                    if ([MPApplication sharedUIApplication].applicationState == UIApplicationStateBackground) {
+                        mpUserAgent = defaultUserAgent;
+                        return;
+                    }
                 }
-#endif
+
                 @try {
                     UIWebView *webView = [[UIWebView alloc] initWithFrame:CGRectZero];
                     mpUserAgent = [webView stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];

--- a/mParticle-Apple-SDK/Notifications/MPNotificationController.h
+++ b/mParticle-Apple-SDK/Notifications/MPNotificationController.h
@@ -3,7 +3,6 @@
 #import "MParticleUserNotification.h"
 
 @protocol MPNotificationControllerDelegate;
-NS_EXTENSION_UNAVAILABLE_IOS("")
 @interface MPNotificationController : NSObject
 
 #if TARGET_OS_IOS == 1
@@ -25,6 +24,6 @@ NS_EXTENSION_UNAVAILABLE_IOS("")
 
 @protocol MPNotificationControllerDelegate <NSObject>
 #if TARGET_OS_IOS == 1
-- (void)receivedUserNotification:(nonnull MParticleUserNotification *)userNotification NS_EXTENSION_UNAVAILABLE_IOS("");
+- (void)receivedUserNotification:(nonnull MParticleUserNotification *)userNotification;
 #endif
 @end

--- a/mParticle-Apple-SDK/Notifications/MPNotificationController.mm
+++ b/mParticle-Apple-SDK/Notifications/MPNotificationController.mm
@@ -5,6 +5,8 @@
 #include "MPHasher.h"
 #import "MParticle.h"
 #import "MPBackendController.h"
+#import "MPApplication.h"
+#import "MPStateMachine.h"
 
 @interface MPNotificationController() {
     BOOL appJustFinishedLaunching;
@@ -95,7 +97,7 @@ static int64_t launchNotificationHash = 0;
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UIUserNotificationSettings *userNotificationSettings = nil;
     if ([NSThread isMainThread]) {
-        userNotificationSettings = [[UIApplication sharedApplication] currentUserNotificationSettings];
+        userNotificationSettings = [[MPApplication sharedUIApplication] currentUserNotificationSettings];
     }
 
     if (!userNotificationSettings) {
@@ -195,7 +197,7 @@ static int64_t launchNotificationHash = 0;
         notificationLaunchedApp = NO;
     }
     
-    if (userNotification && shouldDelegateReceivedRemoteNotification) {
+    if (userNotification && shouldDelegateReceivedRemoteNotification && ![MPStateMachine isAppExtension]) {
         [self.delegate receivedUserNotification:userNotification];
     }
 }

--- a/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
+++ b/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm
@@ -1624,7 +1624,7 @@ const int MaxBreadcrumbs = 50;
         
         
         auxString = string([message.uuid UTF8String]);
-        sqlite3_bind_text(preparedStatement, 3, auxString.c_str(), (int)auxString.size(), SQLITE_STATIC);
+        sqlite3_bind_text(preparedStatement, 3, auxString.c_str(), (int)auxString.size(), SQLITE_TRANSIENT);
         
         sqlite3_bind_double(preparedStatement, 4, message.timestamp);
         sqlite3_bind_blob(preparedStatement, 5, [message.messageData bytes], (int)[message.messageData length], SQLITE_STATIC);

--- a/mParticle-Apple-SDK/Utils/MPApplication.h
+++ b/mParticle-Apple-SDK/Utils/MPApplication.h
@@ -1,6 +1,8 @@
 #import "MPIConstants.h"
 #import "MPEnums.h"
 
+@class UIApplication;
+
 extern NSString * _Nonnull const kMPApplicationInformationKey;
 
 @interface MPApplication : NSObject <NSCopying>
@@ -32,6 +34,7 @@ extern NSString * _Nonnull const kMPApplicationInformationKey;
 + (void)updateLastUseDate:(nonnull NSDate *)date;
 + (void)updateLaunchCountsAndDates;
 + (void)updateStoredVersionAndBuildNumbers;
++ (UIApplication *_Nullable)sharedUIApplication;
 - (nonnull NSDictionary<NSString *, id> *)dictionaryRepresentation;
 
 @end

--- a/mParticle-Apple-SDK/Utils/MPCurrentState.m
+++ b/mParticle-Apple-SDK/Utils/MPCurrentState.m
@@ -1,6 +1,7 @@
 #import "MPCurrentState.h"
 #import <mach/mach.h>
 #import "MPStateMachine.h"
+#import "MPApplication.h"
 
 #if TARGET_OS_IOS == 1
     #import <CoreLocation/CoreLocation.h>
@@ -189,12 +190,11 @@ NSString *const kMPStateFreeDiskSpaceKey = @"fds";
 }
 
 - (NSNumber *)statusBarOrientation {
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-    if ([NSThread isMainThread]) {
-        _statusBarOrientation = @([[UIApplication sharedApplication] statusBarOrientation]);
+    if (![MPStateMachine isAppExtension]) {
+        if ([NSThread isMainThread]) {
+            _statusBarOrientation = @([[MPApplication sharedUIApplication] statusBarOrientation]);
+        }
     }
-#endif
-    
     return _statusBarOrientation;
 }
 #endif

--- a/mParticle-Apple-SDK/Utils/MPDevice.m
+++ b/mParticle-Apple-SDK/Utils/MPDevice.m
@@ -519,9 +519,9 @@ int main(int argc, char *argv[]);
     }
     
     NSData *pushNotificationToken;
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-    pushNotificationToken = [MPNotificationController deviceToken];
-#endif
+    if (![MPStateMachine isAppExtension]) {
+        pushNotificationToken = [MPNotificationController deviceToken];
+    }
     if (pushNotificationToken) {
         deviceDictionary[kMPDeviceTokenKey] = [NSString stringWithFormat:@"%@", pushNotificationToken];
     }

--- a/mParticle-Apple-SDK/Utils/MPMessageBuilder.mm
+++ b/mParticle-Apple-SDK/Utils/MPMessageBuilder.mm
@@ -15,6 +15,7 @@
 #import "MPUserAttributeChange.h"
 #import "MPUserIdentityChange.h"
 #import "MPPersistenceController.h"
+#import "MPApplication.h"
 
 NSString *const launchInfoStringFormat = @"%@%@%@=%@";
 NSString *const kMPHorizontalAccuracyKey = @"acc";
@@ -77,12 +78,13 @@ NSString *const kMPUserIdentityOldValueKey = @"oi";
     NSString *presentedViewControllerDescription = nil;
     NSNumber *mainThreadFlag;
     if ([NSThread isMainThread]) {
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-        UIViewController *presentedViewController = [UIApplication sharedApplication].keyWindow.rootViewController.presentedViewController;
-        presentedViewControllerDescription = presentedViewController ? [[presentedViewController class] description] : nil;
-#else
-        presentedViewControllerDescription = @"extension_message";
-#endif
+        if (![MPStateMachine isAppExtension]) {
+            UIViewController *presentedViewController = [MPApplication sharedUIApplication].keyWindow.rootViewController.presentedViewController;
+            presentedViewControllerDescription = presentedViewController ? [[presentedViewController class] description] : nil;
+        } else {
+            presentedViewControllerDescription = @"extension_message";
+        }
+        
         mainThreadFlag = @YES;
     } else {
         presentedViewControllerDescription = @"off_thread";

--- a/mParticle-Apple-SDK/Utils/MPResponseConfig.m
+++ b/mParticle-Apple-SDK/Utils/MPResponseConfig.m
@@ -6,6 +6,7 @@
 #import "MPStateMachine.h"
 #import "MPIUserDefaults.h"
 #import "MPPersistenceController.h"
+#import "MPApplication.h"
 
 #if TARGET_OS_IOS == 1
     #import <CoreLocation/CoreLocation.h>
@@ -36,14 +37,22 @@
         if (!MPIsNull(self->_configuration[kMPRemoteConfigKitsKey])) {
             for (NSDictionary *kitDictionary in self->_configuration[kMPRemoteConfigKitsKey]) {
                 
-                BOOL hasConsentKitFilter = kitDictionary[kMPConsentKitFilter] != nil;
+                NSDictionary *consentKitFilter = kitDictionary[kMPConsentKitFilter];
+                BOOL hasConsentKitFilter = MPIsNonEmptyDictionary(consentKitFilter);
+                
                 BOOL hasRegulationOrPurposeFilters = NO;
                 
                 NSDictionary *hashes = kitDictionary[kMPRemoteConfigKitHashesKey];
                 
-                if (hashes != nil && [hashes isKindOfClass:[NSDictionary class]]) {
+                if (MPIsNonEmptyDictionary(hashes)) {
                     
-                    if (hashes[kMPConsentRegulationFilters] != nil || hashes[kMPConsentPurposeFilters] != nil) {
+                    NSDictionary *regulationFilters = hashes[kMPConsentRegulationFilters];
+                    NSDictionary *purposeFilters = hashes[kMPConsentPurposeFilters];
+                    
+                    BOOL hasRegulationFilters = MPIsNonEmptyDictionary(regulationFilters);
+                    BOOL hasPurposeFilters = MPIsNonEmptyDictionary(purposeFilters);
+                    
+                    if (hasRegulationFilters || hasPurposeFilters) {
                         hasRegulationOrPurposeFilters = YES;
                     }
                     
@@ -65,7 +74,7 @@
         BOOL shouldDefer = hasConsentFilters && !hasInitialIdentity;
         
         if (!shouldDefer) {
-            dispatch_sync(dispatch_get_main_queue(), ^{
+            dispatch_async(dispatch_get_main_queue(), ^{
                 [[MPKitContainer sharedInstance] configureKits:self->_configuration[kMPRemoteConfigKitsKey]];
             });
         } else {
@@ -159,19 +168,19 @@
 - (void)configurePushNotifications:(NSDictionary *)pushNotificationDictionary {
     NSString *pushNotificationMode = pushNotificationDictionary[kMPRemoteConfigPushNotificationModeKey];
     [MPStateMachine sharedInstance].pushNotificationMode = pushNotificationMode;
-#if !defined(MPARTICLE_APP_EXTENSIONS)
-    UIApplication *app = [UIApplication sharedApplication];
-    
-    if ([pushNotificationMode isEqualToString:kMPRemoteConfigForceTrue]) {
-        NSNumber *pushNotificationType = pushNotificationDictionary[kMPRemoteConfigPushNotificationTypeKey];
+    if (![MPStateMachine isAppExtension]) {
+        UIApplication *app = [MPApplication sharedUIApplication];
+        
+        if ([pushNotificationMode isEqualToString:kMPRemoteConfigForceTrue]) {
+            NSNumber *pushNotificationType = pushNotificationDictionary[kMPRemoteConfigPushNotificationTypeKey];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        [app registerForRemoteNotificationTypes:[pushNotificationType integerValue]];
+            [app registerForRemoteNotificationTypes:[pushNotificationType integerValue]];
 #pragma clang diagnostic pop
-    } else if ([pushNotificationMode isEqualToString:kMPRemoteConfigForceFalse]) {
-        [app unregisterForRemoteNotifications];
+        } else if ([pushNotificationMode isEqualToString:kMPRemoteConfigForceFalse]) {
+            [app unregisterForRemoteNotifications];
+        }
     }
-#endif
 }
 #endif
 

--- a/mParticle-Apple-SDK/Utils/MPSearchAdsAttribution.m
+++ b/mParticle-Apple-SDK/Utils/MPSearchAdsAttribution.m
@@ -1,5 +1,6 @@
 #import "MPSearchAdsAttribution.h"
 #import "mParticle.h"
+#import "MPStateMachine.h"
 
 #if TARGET_OS_IOS == 1
     #import <iAd/ADClient.h>
@@ -30,93 +31,99 @@
 }
 
 - (void)requestAttributionDetailsWithBlock:(void (^ _Nonnull)(void))completionHandler {
-#if TARGET_OS_IOS == 1 && __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_9_3 && !defined(MPARTICLE_APP_EXTENSIONS)
-    Class MPClientClass = NSClassFromString(@"ADClient");
-    if (!MPClientClass) {
-        completionHandler();
-        return;
-    }
+#if TARGET_OS_IOS == 1 && __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_9_3
+    if (![MPStateMachine isAppExtension]) {
+        Class MPClientClass = NSClassFromString(@"ADClient");
+        if (!MPClientClass) {
+            completionHandler();
+            return;
+        }
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-    SEL sharedClientSelector = NSSelectorFromString(@"sharedClient");
-    if (![MPClientClass respondsToSelector:sharedClientSelector]) {
-        completionHandler();
-        return;
-    }
-    
-    id MPClientSharedInstance = [MPClientClass performSelector:sharedClientSelector];
-    if (!MPClientSharedInstance) {
-        completionHandler();
-        return;
-    }
-    
-    SEL requestDetailsSelector = NSSelectorFromString(@"requestAttributionDetailsWithBlock:");
-    if (![MPClientSharedInstance respondsToSelector:requestDetailsSelector]) {
-        completionHandler();
-        return;
-    }
-    
-    __block BOOL called = NO;
-    void(^onceCompletionBlock)(void) = ^(){
-        if (!called) {
-            called = YES;
-            dispatch_async(self->messageQueue, ^{
-                completionHandler();
-            });
+        SEL sharedClientSelector = NSSelectorFromString(@"sharedClient");
+        if (![MPClientClass respondsToSelector:sharedClientSelector]) {
+            completionHandler();
+            return;
         }
-    };
-    
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(30 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        onceCompletionBlock();
-    });
-    
-    __weak MPSearchAdsAttribution *weakSelf = self;
-    int numRequests = 4;
-    __block int numRequestsCompleted = 0;
-    
-    void (^requestBlock)(void) = ^{
-        if (!called) {
-            [MPClientSharedInstance performSelector:requestDetailsSelector withObject:^(NSDictionary *attributionDetails, NSError *error) {
-                ++numRequestsCompleted;
-                
-                __strong MPSearchAdsAttribution *strongSelf = weakSelf;
-                if (!strongSelf) {
-                    return;
-                }
-
-                if (!strongSelf.dictionary && attributionDetails && !error) {
-                    NSDictionary* deepCopyDetails = nil;
-                    @try {
-                        deepCopyDetails = [NSKeyedUnarchiver unarchiveObjectWithData:
-                                                         [NSKeyedArchiver archivedDataWithRootObject:attributionDetails]];
-                    }
-                    @catch (NSException *e) {
-                        deepCopyDetails = [attributionDetails copy];
-                    }
-
-                    if (deepCopyDetails) {
-                        strongSelf.dictionary = deepCopyDetails;
-                    }
-                    
-                    onceCompletionBlock();
-                }
-                else if (error.code == 1 /* ADClientErrorLimitAdTracking */) {
-                    onceCompletionBlock();
-                }
-                else if (numRequestsCompleted >= numRequests) {
-                    onceCompletionBlock();
-                }
-            }];
+        
+        id MPClientSharedInstance = [MPClientClass performSelector:sharedClientSelector];
+        if (!MPClientSharedInstance) {
+            completionHandler();
+            return;
         }
-    };
-    
-    // Per Apple docs, "Handle any errors you receive and re-poll for data, if required"
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0 * NSEC_PER_SEC)), dispatch_get_main_queue(), requestBlock);
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)), dispatch_get_main_queue(), requestBlock);
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(6 * NSEC_PER_SEC)), dispatch_get_main_queue(), requestBlock);
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(9 * NSEC_PER_SEC)), dispatch_get_main_queue(), requestBlock);
-    
+        
+        SEL requestDetailsSelector = NSSelectorFromString(@"requestAttributionDetailsWithBlock:");
+        if (![MPClientSharedInstance respondsToSelector:requestDetailsSelector]) {
+            completionHandler();
+            return;
+        }
+        
+        __block BOOL called = NO;
+        void(^onceCompletionBlock)(void) = ^(){
+            if (!called) {
+                called = YES;
+                dispatch_async(self->messageQueue, ^{
+                    completionHandler();
+                });
+            }
+        };
+        
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(30 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            onceCompletionBlock();
+        });
+        
+        __weak MPSearchAdsAttribution *weakSelf = self;
+        int numRequests = 4;
+        __block int numRequestsCompleted = 0;
+        
+        void (^requestBlock)(void) = ^{
+            if (!called) {
+                [MPClientSharedInstance performSelector:requestDetailsSelector withObject:^(NSDictionary *attributionDetails, NSError *error) {
+                    dispatch_async([MParticle messageQueue], ^{
+                        ++numRequestsCompleted;
+                        
+                        __strong MPSearchAdsAttribution *strongSelf = weakSelf;
+                        if (!strongSelf) {
+                            return;
+                        }
+                        
+                        if (!strongSelf.dictionary && attributionDetails && !error) {
+                            NSDictionary* deepCopyDetails = nil;
+                            @try {
+                                deepCopyDetails = [NSKeyedUnarchiver unarchiveObjectWithData:
+                                                   [NSKeyedArchiver archivedDataWithRootObject:attributionDetails]];
+                            }
+                            @catch (NSException *e) {
+                                deepCopyDetails = [attributionDetails copy];
+                            }
+                            
+                            if (deepCopyDetails) {
+                                strongSelf.dictionary = deepCopyDetails;
+                            }
+                            
+                            onceCompletionBlock();
+                        }
+                        else if (error.code == 1 /* ADClientErrorLimitAdTracking */) {
+                            onceCompletionBlock();
+                        }
+                        else if (numRequestsCompleted >= numRequests) {
+                            onceCompletionBlock();
+                        }
+                    });
+                }];
+            }
+        };
+        
+        // Per Apple docs, "Handle any errors you receive and re-poll for data, if required"
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0 * NSEC_PER_SEC)), dispatch_get_main_queue(), requestBlock);
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)), dispatch_get_main_queue(), requestBlock);
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(6 * NSEC_PER_SEC)), dispatch_get_main_queue(), requestBlock);
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(9 * NSEC_PER_SEC)), dispatch_get_main_queue(), requestBlock);
+        
 #pragma clang diagnostic pop
+    } else {
+        completionHandler();
+    }
 #else
     completionHandler();
 #endif

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.h
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.h
@@ -61,6 +61,7 @@ typedef NS_ENUM(NSUInteger, MPConsoleLogging) {
 + (nullable NSString *)provisioningProfileString;
 + (BOOL)runningInBackground;
 + (void)setRunningInBackground:(BOOL)background;
++ (BOOL)isAppExtension;
 - (void)configureCustomModules:(nullable NSArray<NSDictionary *> *)customModuleSettings;
 - (void)configureRampPercentage:(nullable NSNumber *)rampPercentage;
 - (void)configureTriggers:(nullable NSDictionary *)triggerDictionary;

--- a/mParticle-Apple-SDK/Utils/MPStateMachine.mm
+++ b/mParticle-Apple-SDK/Utils/MPStateMachine.mm
@@ -346,6 +346,14 @@ static BOOL runningInBackground = NO;
     runningInBackground = background;
 }
 
++ (BOOL)isAppExtension {
+#if TARGET_OS_IOS == 1
+    return [[NSBundle mainBundle].bundlePath hasSuffix:@".appex"];
+#else
+    return NO;
+#endif
+}
+
 #pragma mark Public accessors
 - (MPConsoleLogging)consoleLogging {
     if (_consoleLogging != MPConsoleLoggingAutoDetect) {

--- a/mParticle-Apple-SDK/mParticle.h
+++ b/mParticle-Apple-SDK/mParticle.h
@@ -245,7 +245,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Application notifications
 #if TARGET_OS_IOS == 1
-#if !defined(MPARTICLE_APP_EXTENSIONS)
 /**
  Informs the mParticle SDK a local notification has been received. This method should be called only if proxiedAppDelegate is disabled.
  @param notification A local notification received by the app
@@ -297,7 +296,6 @@ NS_ASSUME_NONNULL_BEGIN
  @see proxiedAppDelegate
  */
 - (void)handleActionWithIdentifier:(nullable NSString *)identifier forRemoteNotification:(nullable NSDictionary *)userInfo;
-#endif
 #endif
 
 /**


### PR DESCRIPTION
## Summary
mParticle sdk crashed on production release 8.11. The reason for crash was mParticle was trying to asynchronously capture the state of sdk while the user kills the application mParticle is now synchronously capturing the state of the sdk

## Testing Plan

## Master Issue
Closes mParticle/issues#

@tspike I'm following these steps. https://gecgithub01.walmart.com/walmartlabs/mobiledev-docs/blob/gh-pages/ios/thirdpartysdk.md 
Will create a qadeployment tag once this is merged.


