### PR TITLE
Build static framework

### DIFF
--- a/mParticle-Apple-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-SDK.xcodeproj/project.pbxproj
@@ -26,9 +26,6 @@
 		C911FD6F1D8A300C002A3516 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD206B1D8A147A00D3ABBE /* UIKit.framework */; };
 		C911FD701D8A3014002A3516 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD206D1D8A148400D3ABBE /* SystemConfiguration.framework */; };
 		C911FD711D8A301C002A3516 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD206F1D8A148C00D3ABBE /* Security.framework */; };
-		C911FD721D8A3023002A3516 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD20711D8A149600D3ABBE /* libz.tbd */; };
-		C911FD731D8A3027002A3516 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD20731D8A14A000D3ABBE /* libsqlite3.tbd */; };
-		C911FD741D8A302C002A3516 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD20751D8A14B200D3ABBE /* libc++.tbd */; };
 		C911FD751D8A3035002A3516 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD20791D8A14C300D3ABBE /* Foundation.framework */; };
 		C911FD761D8A303C002A3516 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD207F1D8A14E200D3ABBE /* CoreGraphics.framework */; };
 		C911FD771D8A3043002A3516 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD20691D8A146F00D3ABBE /* AdSupport.framework */; };
@@ -386,9 +383,6 @@
 		C9DD206C1D8A147A00D3ABBE /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD206B1D8A147A00D3ABBE /* UIKit.framework */; };
 		C9DD206E1D8A148400D3ABBE /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD206D1D8A148400D3ABBE /* SystemConfiguration.framework */; };
 		C9DD20701D8A148C00D3ABBE /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD206F1D8A148C00D3ABBE /* Security.framework */; };
-		C9DD20721D8A149600D3ABBE /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD20711D8A149600D3ABBE /* libz.tbd */; };
-		C9DD20741D8A14A000D3ABBE /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD20731D8A14A000D3ABBE /* libsqlite3.tbd */; };
-		C9DD20761D8A14B200D3ABBE /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD20751D8A14B200D3ABBE /* libc++.tbd */; };
 		C9DD20781D8A14BA00D3ABBE /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD20771D8A14BA00D3ABBE /* iAd.framework */; };
 		C9DD207A1D8A14C300D3ABBE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD20791D8A14C300D3ABBE /* Foundation.framework */; };
 		C9DD207C1D8A14CE00D3ABBE /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD207B1D8A14CE00D3ABBE /* CoreTelephony.framework */; };
@@ -484,8 +478,6 @@
 		DB8398442088F0EC0031AB1D /* MPConsentSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DB8398422088F0EC0031AB1D /* MPConsentSerializationTests.m */; };
 		DB8C8A391FBCA63200DEC7C2 /* MParticleOptionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DB8C8A381FBCA63200DEC7C2 /* MParticleOptionsTests.m */; };
 		DB8C8A3A1FBCA63200DEC7C2 /* MParticleOptionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DB8C8A381FBCA63200DEC7C2 /* MParticleOptionsTests.m */; };
-		DB93D90A20AC86AB00A974E7 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C9DD20731D8A14A000D3ABBE /* libsqlite3.tbd */; };
-		DB93D90C20AC86B700A974E7 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = DB93D90B20AC86B700A974E7 /* libsqlite3.tbd */; };
 		DB9AA1A21EFD806000340D02 /* MPIUserDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = DB9AA19E1EFD806000340D02 /* MPIUserDefaults.h */; };
 		DB9AA1A31EFD806000340D02 /* MPIUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = DB9AA19F1EFD806000340D02 /* MPIUserDefaults.m */; };
 		DBA42900205ADEB7006AB971 /* MPConvertJSTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DBA428FF205ADEB7006AB971 /* MPConvertJSTests.m */; };
@@ -708,9 +700,6 @@
 		C9DD206B1D8A147A00D3ABBE /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		C9DD206D1D8A148400D3ABBE /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		C9DD206F1D8A148C00D3ABBE /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
-		C9DD20711D8A149600D3ABBE /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
-		C9DD20731D8A14A000D3ABBE /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
-		C9DD20751D8A14B200D3ABBE /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		C9DD20771D8A14BA00D3ABBE /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
 		C9DD20791D8A14C300D3ABBE /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		C9DD207B1D8A14CE00D3ABBE /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
@@ -799,7 +788,6 @@
 		DB83983D2087E8780031AB1D /* MPConsentSerialization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPConsentSerialization.m; sourceTree = "<group>"; };
 		DB8398422088F0EC0031AB1D /* MPConsentSerializationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPConsentSerializationTests.m; sourceTree = "<group>"; };
 		DB8C8A381FBCA63200DEC7C2 /* MParticleOptionsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MParticleOptionsTests.m; sourceTree = "<group>"; };
-		DB93D90B20AC86B700A974E7 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS11.3.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
 		DB9AA19E1EFD806000340D02 /* MPIUserDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPIUserDefaults.h; sourceTree = "<group>"; };
 		DB9AA19F1EFD806000340D02 /* MPIUserDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPIUserDefaults.m; sourceTree = "<group>"; };
 		DBA428FF205ADEB7006AB971 /* MPConvertJSTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPConvertJSTests.m; sourceTree = "<group>"; };
@@ -821,7 +809,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB93D90C20AC86B700A974E7 /* libsqlite3.tbd in Frameworks */,
 				C911FD811D8A3524002A3516 /* mParticle_Apple_SDK.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -833,9 +820,6 @@
 				C911FD771D8A3043002A3516 /* AdSupport.framework in Frameworks */,
 				C911FD761D8A303C002A3516 /* CoreGraphics.framework in Frameworks */,
 				C911FD751D8A3035002A3516 /* Foundation.framework in Frameworks */,
-				C911FD741D8A302C002A3516 /* libc++.tbd in Frameworks */,
-				C911FD731D8A3027002A3516 /* libsqlite3.tbd in Frameworks */,
-				C911FD721D8A3023002A3516 /* libz.tbd in Frameworks */,
 				C911FD711D8A301C002A3516 /* Security.framework in Frameworks */,
 				C911FD701D8A3014002A3516 /* SystemConfiguration.framework in Frameworks */,
 				C911FD6F1D8A300C002A3516 /* UIKit.framework in Frameworks */,
@@ -852,9 +836,6 @@
 				C9DD207C1D8A14CE00D3ABBE /* CoreTelephony.framework in Frameworks */,
 				C9DD207A1D8A14C300D3ABBE /* Foundation.framework in Frameworks */,
 				C9DD20781D8A14BA00D3ABBE /* iAd.framework in Frameworks */,
-				C9DD20761D8A14B200D3ABBE /* libc++.tbd in Frameworks */,
-				C9DD20741D8A14A000D3ABBE /* libsqlite3.tbd in Frameworks */,
-				C9DD20721D8A149600D3ABBE /* libz.tbd in Frameworks */,
 				C9DD20701D8A148C00D3ABBE /* Security.framework in Frameworks */,
 				C9DD206E1D8A148400D3ABBE /* SystemConfiguration.framework in Frameworks */,
 				C9DD206C1D8A147A00D3ABBE /* UIKit.framework in Frameworks */,
@@ -866,7 +847,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB93D90A20AC86AB00A974E7 /* libsqlite3.tbd in Frameworks */,
 				C9DD21051D8A22B000D3ABBE /* mParticle_Apple_SDK.framework in Frameworks */,
 				D37A016E20A0D2C000FF2B0F /* libOCMock.a in Frameworks */,
 			);
@@ -1220,16 +1200,12 @@
 		C9DD20661D8A146900D3ABBE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				DB93D90B20AC86B700A974E7 /* libsqlite3.tbd */,
 				C91E3AE81D92CFA00062B8DA /* UserNotifications.framework */,
 				C9DD207F1D8A14E200D3ABBE /* CoreGraphics.framework */,
 				C9DD207D1D8A14D800D3ABBE /* CoreLocation.framework */,
 				C9DD207B1D8A14CE00D3ABBE /* CoreTelephony.framework */,
 				C9DD20791D8A14C300D3ABBE /* Foundation.framework */,
 				C9DD20771D8A14BA00D3ABBE /* iAd.framework */,
-				C9DD20751D8A14B200D3ABBE /* libc++.tbd */,
-				C9DD20731D8A14A000D3ABBE /* libsqlite3.tbd */,
-				C9DD20711D8A149600D3ABBE /* libz.tbd */,
 				C9DD206F1D8A148C00D3ABBE /* Security.framework */,
 				C9DD206D1D8A148400D3ABBE /* SystemConfiguration.framework */,
 				C9DD206B1D8A147A00D3ABBE /* UIKit.framework */,
@@ -2120,8 +2096,15 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "./Framework/mParticle-Apple-SDK.modulemap";
 				ONLY_ACTIVE_ARCH = NO;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+					"-lz",
+					"-lsqlite3",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Apple-SDK";
 				PRODUCT_NAME = mParticle_Apple_SDK;
 				SKIP_INSTALL = YES;
@@ -2164,7 +2147,10 @@
 					"$(PROJECT_DIR)/UnitTests/Libraries",
 				);
 				MACH_O_TYPE = mh_dylib;
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lz",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-iOS-SDKTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -2416,7 +2402,14 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "./Framework/mParticle-Apple-SDK.modulemap";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+					"-lz",
+					"-lsqlite3",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Apple-SDK";
 				PRODUCT_NAME = mParticle_Apple_SDK;
 				SKIP_INSTALL = YES;
@@ -2439,7 +2432,14 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "./Framework/mParticle-Apple-SDK.modulemap";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+					"-lz",
+					"-lsqlite3",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Apple-SDK";
 				PRODUCT_NAME = mParticle_Apple_SDK;
 				SKIP_INSTALL = YES;
@@ -2460,7 +2460,10 @@
 					"$(PROJECT_DIR)/UnitTests/Libraries",
 				);
 				MACH_O_TYPE = mh_dylib;
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lz",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-iOS-SDKTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary
Build mParticle-Apple-SDK as a static framework:
- Link libz, libsqlite3, libc++ with linker flags.
- Change Mach-o type to static library
- Additionally, linking libz was required in unit test target.

## Testing Plan
Tested by integrating static framework inside Walmart.app. 
Verified mParticle-iOS-SDK, mParticle_iOS_SDKTests builds successfully.
Regression will be done by core team QA.

## Master Issue
N/A
